### PR TITLE
`rex_sql::getArray()` return type depends on `PDO::FETCH_*`

### DIFF
--- a/lib/RexSqlReflection.php
+++ b/lib/RexSqlReflection.php
@@ -82,9 +82,10 @@ final class RexSqlReflection
     }
 
     /**
+     * @param QueryReflector::FETCH_* $fetchType
      * @throws UnresolvableQueryException
      */
-    public static function inferStatementType(Expr $queryExpr, ?Type $parameterTypes, Scope $scope): ?Type
+    public static function inferStatementType(Expr $queryExpr, ?Type $parameterTypes, Scope $scope, int $fetchType): ?Type
     {
         if (null === $parameterTypes) {
             $queryReflection = new QueryReflection();
@@ -94,22 +95,23 @@ final class RexSqlReflection
             $queryStrings = $queryReflection->resolvePreparedQueryStrings($queryExpr, $parameterTypes, $scope);
         }
 
-        return self::createGenericObject($queryStrings);
+        return self::createGenericObject($queryStrings, $fetchType);
     }
 
     /**
+     * @param QueryReflector::FETCH_* $fetchType
      * @param iterable<string>            $queryStrings
      */
-    private static function createGenericObject(iterable $queryStrings): ?Type
+    private static function createGenericObject(iterable $queryStrings, int $fetchType): ?Type
     {
         $queryReflection = new QueryReflection();
         $genericObjects = [];
 
         foreach ($queryStrings as $queryString) {
-            $assocType = $queryReflection->getResultType($queryString, QueryReflector::FETCH_TYPE_ASSOC);
+            $resultType = $queryReflection->getResultType($queryString, $fetchType);
 
-            if (null !== $assocType) {
-                $genericObjects[] = new GenericObjectType(rex_sql::class, [$assocType]);
+            if (null !== $resultType) {
+                $genericObjects[] = new GenericObjectType(rex_sql::class, [$resultType]);
             }
         }
 

--- a/lib/RexSqlSetQueryTypeSpecifyingExtension.php
+++ b/lib/RexSqlSetQueryTypeSpecifyingExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\MethodTypeSpecifyingExtension;
 use PHPStan\Type\Type;
 use rex_sql;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
 use staabm\PHPStanDba\UnresolvableQueryException;
 use function count;
 
@@ -76,6 +77,6 @@ final class RexSqlSetQueryTypeSpecifyingExtension implements MethodTypeSpecifyin
             $parameterTypes = $scope->getType($args[1]->value);
         }
 
-        return RexSqlReflection::inferStatementType($queryExpr, $parameterTypes, $scope);
+        return RexSqlReflection::inferStatementType($queryExpr, $parameterTypes, $scope, QueryReflector::FETCH_TYPE_ASSOC);
     }
 }

--- a/tests/data/sql-get-array.php
+++ b/tests/data/sql-get-array.php
@@ -2,6 +2,7 @@
 
 namespace RexSqlGetArray;
 
+use PDO;
 use rex;
 use rex_sql;
 use function PHPStan\Testing\assertType;
@@ -15,7 +16,7 @@ function getArray(): void
             LIMIT   1
         ');
 
-    assertType('array<string, array{name: string}>', $array);
+    assertType('array<int, array{name: string}>', $array);
 }
 
 function getArray0(int $id): void
@@ -28,7 +29,7 @@ function getArray0(int $id): void
             LIMIT   1
         ', [$id]);
 
-    assertType('array<string, array{name: string}>', $array);
+    assertType('array<int, array{name: string}>', $array);
 }
 
 function getArray1(int $id): void
@@ -39,9 +40,9 @@ function getArray1(int $id): void
             FROM    ' . rex::getTable('article') . '
             WHERE   id = ?
             LIMIT   1
-        ', [$id], \PDO::FETCH_ASSOC);
+        ', [$id], PDO::FETCH_ASSOC);
 
-    assertType('array<string, array{name: string}>', $array);
+    assertType('array<int, array{name: string}>', $array);
 }
 
 function getArray2(int $id): void
@@ -52,7 +53,7 @@ function getArray2(int $id): void
             FROM    ' . rex::getTable('article') . '
             WHERE   id = ?
             LIMIT   1
-        ', [$id], \PDO::FETCH_NUM);
+        ', [$id], PDO::FETCH_NUM);
 
-    assertType('array<int, array{name: string}>', $array);
+    assertType('array<int, array{string}>', $array);
 }

--- a/tests/data/sql-get-array.php
+++ b/tests/data/sql-get-array.php
@@ -6,7 +6,19 @@ use rex;
 use rex_sql;
 use function PHPStan\Testing\assertType;
 
-function getArray(int $id): void
+function getArray(): void
+{
+    $sql = rex_sql::factory();
+    $array = $sql->getArray('
+            SELECT  name
+            FROM    ' . rex::getTable('article') . '
+            LIMIT   1
+        ');
+
+    assertType('array<string, array{name: string}>', $array);
+}
+
+function getArray0(int $id): void
 {
     $sql = rex_sql::factory();
     $array = $sql->getArray('
@@ -15,6 +27,32 @@ function getArray(int $id): void
             WHERE   id = ?
             LIMIT   1
         ', [$id]);
+
+    assertType('array<string, array{name: string}>', $array);
+}
+
+function getArray1(int $id): void
+{
+    $sql = rex_sql::factory();
+    $array = $sql->getArray('
+            SELECT  name
+            FROM    ' . rex::getTable('article') . '
+            WHERE   id = ?
+            LIMIT   1
+        ', [$id], \PDO::FETCH_ASSOC);
+
+    assertType('array<string, array{name: string}>', $array);
+}
+
+function getArray2(int $id): void
+{
+    $sql = rex_sql::factory();
+    $array = $sql->getArray('
+            SELECT  name
+            FROM    ' . rex::getTable('article') . '
+            WHERE   id = ?
+            LIMIT   1
+        ', [$id], \PDO::FETCH_NUM);
 
     assertType('array<int, array{name: string}>', $array);
 }


### PR DESCRIPTION
siehe https://github.com/redaxo/redaxo/blob/4465a7ba273c3aaf02bf7ac80f073f9c89dad682/redaxo/src/core/lib/sql/sql.php#L1215