### PR TITLE
Analysis output

### DIFF
--- a/assets/rexstan.css
+++ b/assets/rexstan.css
@@ -8,12 +8,24 @@
     }
 }
 
-
 .rexstan-achievement {
     font-size: 50px;
+    height: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
 
-    height : 100px;
-    display : flex;
-    align-items : center;
-    justify-content : center;
+.rexstan-linenumber {
+    display: inline-block;
+    width: 5rem;
+    text-align: right;
+}
+
+.rexstan .panel-heading:not(.collapsed) .rexstan-open {
+    display: none;
+}
+
+.rexstan .panel-heading.collapsed .rexstan-closed {
+    display: none;
 }

--- a/assets/rexstan.css
+++ b/assets/rexstan.css
@@ -16,9 +16,15 @@
     justify-content: center;
 }
 
+.rexstan-message {
+    padding-left: 6rem;
+    text-indent:-5rem;
+}
+
 .rexstan-linenumber {
     display: inline-block;
     width: 5rem;
+    padding-right: 0.5rem;
     text-align: right;
 }
 

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -121,7 +121,7 @@ if (
 
         $section->setVar('title', $title, false);
         $section->setVar('collapse', true);
-        $section->setVar('collapsed', 15 < $totalErrors && 1 < count($phpstanResult['files']));
+        // $section->setVar('collapsed', 15 < $totalErrors && 1 < count($phpstanResult['files']));
         $content = '<ul class="list-group">';
         foreach ($fileResult['messages'] as $message) {
             $content .= '<li class="list-group-item rexstan-message">';

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -120,7 +120,7 @@ if (
                  ' <span class="badge">'.$fileResult['errors'].'</span>';
 
         $section->setVar('title', $title, false);
-        $section->setVar('collapse', $collapsed);
+        $section->setVar('collapse', true);
         $section->setVar('collapsed', 15 < $totalErrors && 1 < count($phpstanResult['files']));
         $content = '<ul class="list-group">';
         foreach ($fileResult['messages'] as $message) {

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -111,8 +111,6 @@ if (
     $section = new rex_fragment();
     $section->setVar('sectionAttributes', ['class' => 'rexstan'], false);
 
-    $collapsed = (15 < $totalErrors);
-
     foreach ($phpstanResult['files'] as $file => $fileResult) {
         $shortFile = str_replace($basePath, '', $file);
         $title = '<i class="rexstan-open fa fa-folder-o"></i>'.
@@ -123,8 +121,7 @@ if (
 
         $section->setVar('title', $title, false);
         $section->setVar('collapse', $collapsed);
-        $section->setVar('collapsed', $collapsed);
-
+        $section->setVar('collapsed', 15 < $totalErrors && 1 < count($phpstanResult['files']));
         $content = '<ul class="list-group">';
         foreach ($fileResult['messages'] as $message) {
             $content .= '<li class="list-group-item">';

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -124,8 +124,8 @@ if (
         $section->setVar('collapsed', 15 < $totalErrors && 1 < count($phpstanResult['files']));
         $content = '<ul class="list-group">';
         foreach ($fileResult['messages'] as $message) {
-            $content .= '<li class="list-group-item">';
-            $content .= '<span class="rexstan-linenumber">' .sprintf('%5d', $message['line']).': </span> ';
+            $content .= '<li class="list-group-item rexstan-message">';
+            $content .= '<span class="rexstan-linenumber">' .sprintf('%5d', $message['line']).':</span>';
             $error = rex_escape($message['message']);
             $url = rex_editor::factory()->getUrl($file, $message['line']);
             if ($url) {


### PR DESCRIPTION
Ich bin über die doch sehr langen Listen gestolpert, die bei vielen Meldungen und/oder vielen Dateien entstehen. Hier mal ein Vorschlag, das etwas anzupassen:

Die Ausgabe der Meldungen erfolgt nun per Fragment core/page/section und nutzt die Möglichkeit, über den Section-Titel (=Dateiname) per "collapse" die Listen zu schrumpfen. Bei kleinen Ergebnislisten (max 15 Meldungen insgesamt oder nur eine Datei) werden die Listen aufgeblendet angezeigt, sonst nur der Titel.

<img width="1188" alt="grafik" src="https://user-images.githubusercontent.com/10065904/183284623-6ba74f56-5e74-426d-9c60-405195d70b75.png">

Die Zeilennummern sind nach vorne gewandert, da die Einträge per UL erzeugt werden. Der Dateiname pro Eintrag ist m.E. nicht mehr nötig. Im Titel wird die Anzahl Meldungen pro Datei mit angezeigt. 

Die System-Fehlermeldungen aus PHP sind optisch auch etwas aufbereitet. 

