### PR TITLE
Formular RexStanSettings inkl. Feld für phpVersion ...

### DIFF
--- a/install.php
+++ b/install.php
@@ -41,7 +41,7 @@ if (!is_file($userConfigPath)) {
         }
     }
 
-    RexStanUserConfig::save(0, $paths, []);
+    RexStanUserConfig::save(0, $paths, [], 70300);
 }
 
 $configFileContent = '# rexstan auto generated file - do not edit, delete, rename'. PHP_EOL . PHP_EOL .

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -37,11 +37,11 @@ final class RexStanSettings
      * @var array<int, string>
      */
     private static $phpVersionList = [
-        70333 => '7.3 [Mindestanforderung für REDAXO    ]',
-        70430 => '7.4',
-        80022 => '8.0',
-        80109 => '8.1',
-        80200 => '8.2',
+        70333 => '7.3.x [Mindestanforderung für REDAXO    ]',
+        70430 => '7.4.x',
+        80022 => '8.0.x',
+        80109 => '8.1.x',
+        80200 => '8.2.x',
     ];
 
     /**

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -32,6 +32,8 @@ namespace redaxo\phpstan;
 use rex_addon;
 use rex_config;
 use rex_config_form;
+use rex_extension;
+use rex_extension_point;
 use rex_path;
 use RexStanUserConfig;
 

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -32,19 +32,12 @@ namespace redaxo\phpstan;
 use rex_addon;
 use rex_config;
 use rex_config_form;
-use rex_extension;
-use rex_extension_point;
 use rex_path;
-use RexStanUserConfig;
 
-use function is_string;
-
-final class RexStanSettings extends rex_config_form
+final class RexStanSettings
 {
     /**
-     * Listen der derzeit verfügbaren phpstan-Extensions ... ['label' => 'pfad_im_addon'].
-     *
-     * @var array<string>
+     * @var array<string, string>
      */
     private static $phpstanExtensions = [
         'Bleeding-Edge' => 'vendor/phpstan/phpstan/conf/bleedingEdge.neon',
@@ -56,9 +49,7 @@ final class RexStanSettings extends rex_config_form
     ];
 
     /**
-     * ... und der Links zu Erläuterungen. ['label' => 'url'].
-     *
-     * @var array<string>
+     * @var array<string, string>
      */
     private static $phpstanExtensionDocLinks = [
         'Bleeding-Edge' => 'https://phpstan.org/blog/what-is-bleeding-edge',
@@ -70,24 +61,20 @@ final class RexStanSettings extends rex_config_form
     ];
 
     /**
-     * Liste der derzeit relevanten PHP-Versionen. [versionId => 'label'].
-     *
-     * @var array<string>
+     * @var array<int, string>
      */
     private static $phpVersionList = [
-       70333 => '7.3 [Mindestanforderung für REDAXO]',
-       70430 => '7.4',
-       80022 => '8.0',
-       80109 => '8.1',
-       80200 => '8.2',
+        70333 => '7.3 [Mindestanforderung für REDAXO    ]',
+        70430 => '7.4',
+        80022 => '8.0',
+        80109 => '8.1',
+        80200 => '8.2',
     ];
 
     /**
-     * Initialisiert das Formular.
-     *
-     * @return void
+     * @return rex_config_form
      */
-    public function init()
+    public static function createForm()
     {
         $extensions = [];
         foreach (self::$phpstanExtensions as $label => $path) {
@@ -99,11 +86,6 @@ final class RexStanSettings extends rex_config_form
             $extensionLinks[] = '<a href="'.$link.'">'.$label.'</a>';
         }
 
-        /**
-         * Liste der analysierbaren Verzeichnisse (= Addons) ermitteln
-         * Sonderfall: developer-Addon.
-         */
-
         $scanTargets = [];
         foreach (rex_addon::getAvailableAddons() as $availableAddon) {
             $scanTargets[$availableAddon->getPath()] = $availableAddon->getName();
@@ -114,147 +96,47 @@ final class RexStanSettings extends rex_config_form
             }
         }
 
-        /**
-         * Die aktuelle PHP-Version des Servers (SAPI) markieren.
-         * Die aktuelle PHP-Version in Terminal/Konsole (CLI) markieren
-         */
-
         $sapiVersion = (int) (PHP_VERSION_ID / 100);
         $cliVersion = (int) shell_exec('php -r \'echo PHP_VERSION_ID;\'');
-        $cliVersion = (int) ($cliVersion/100);
+        $cliVersion = (int) ($cliVersion / 100);
 
         $phpVersions = self::$phpVersionList;
-        foreach( $phpVersions as $key=>&$label ) {
-            $key = (int) $key/100;
-            if( $key === $sapiVersion) {
-                $label .= ' [aktuelle Webserver-Version (SAPI)]';
+        foreach ($phpVersions as $key => &$label) {
+            $key = (int) ($key / 100);
+
+            if ($key === $sapiVersion) {
+                $label .= ' [aktuelle Webserver-Version (WEB-SAPI)]';
             }
-            if( $key === $cliVersion) {
-                $label .= ' [aktuelle Konsolen-Version (CLI)]';
+            if ($key === $cliVersion) {
+                $label .= ' [aktuelle Konsolen-Version (CLI-SAPI)]';
             }
         }
 
-        $field = $this->addInputField('number', 'level', null, ['class' => 'form-control', 'min' => 0, 'max' => 9]);
+        $form = rex_config_form::factory('rexstan');
+        $field = $form->addInputField('number', 'level', null, ['class' => 'form-control', 'min' => 0, 'max' => 9]);
         $field->setLabel('Level');
         $field->setNotice('0 is the loosest and 9 is the strictest - <a href="https://phpstan.org/user-guide/rule-levels">see PHPStan Rule Levels</a>');
 
-        $field = $this->addSelectField('paths', null, ['class' => 'form-control selectpicker', 'data-live-search' => 'true', 'required' => 'required']); // die Klasse selectpicker aktiviert den Selectpicker von Bootstrap
+        $field = $form->addSelectField('addons', null, ['class' => 'form-control selectpicker', 'data-live-search' => 'true', 'required' => 'required']); // die Klasse selectpicker aktiviert den Selectpicker von Bootstrap
         $field->setAttribute('multiple', 'multiple');
         $field->setLabel('AddOns');
         $field->setNotice('AddOns, die untersucht werden sollen');
         $select = $field->getSelect();
         $select->addOptions($scanTargets);
 
-        $field = $this->addSelectField('includes', null, ['class' => 'form-control selectpicker']);
+        $field = $form->addSelectField('extensions', null, ['class' => 'form-control selectpicker']);
         $field->setAttribute('multiple', 'multiple');
         $field->setLabel('PHPStan Extensions');
         $field->setNotice('Weiterlesen bzgl. der verf&uuml;gbaren Extensions: '.implode(', ', $extensionLinks));
         $select = $field->getSelect();
         $select->addOptions($extensions);
 
-        $field = $this->addSelectField('phpVersion', null, ['class' => 'form-control selectpicker']);
+        $field = $form->addSelectField('phpversion', null, ['class' => 'form-control selectpicker']);
         $field->setLabel('PHP-Version');
         $field->setNotice('Referenz-Version für die Code-Analyse');
         $select = $field->getSelect();
         $select->addOptions($phpVersions);
-    }
 
-    /**
-     * Feldwerte abrufen aus userConf, defaultConf oder rex_config.
-     *
-     * Die Parent-Methode ruft ausschließlich Werte aus der Tabelle rex_config ab.
-     * Die überschriebene Methode versucht zunächst auf phpstan-Settings zuzugreifen.
-     * Kommt der NAme nicht in der Liste (switch..) vor, wird unter dem Namen auf
-     * rex_config zurückgegriffen.
-     *
-     * @param string $name  Der Feldname
-     *
-     * @return mixed  Der zum Feld gehörende Wert; default=''
-     */
-    protected function getValue($name)
-    {
-        switch ($name) {
-            // Zunächst die phpstan-Parameter abrufen
-            case 'level':
-                $value = RexStanUserConfig::getLevel();
-                break;
-            case 'paths':
-                $value = RexStanUserConfig::getPaths();
-                break;
-            case 'phpVersion':
-                $value = RexStanUserConfig::getPhpVersion();
-                break;
-            case 'includes':
-                $value = RexStanUserConfig::getIncludes();
-                break;
-
-                // Default: als rex_config-Wert behandeln
-            default:
-                $value = parent::getValue($name);
-        }
-
-        return $value;
-    }
-
-    /**
-     * Speichert die Änderungen des Settings-Formuars.
-     *
-     * Die Parent-Methode schreibt die Werte in die Tabelle rex_config.
-     * Hier werden zunächst die für phpstan vorgesehenen Werte abgefangen und in die $userConf
-     * übertragen. Am Ende wird $userConf auf die Platte geschrieben.
-     * Alle übrigen Felder werden als rex_config gespeichert.
-     */
-    protected function save(): bool
-    {
-    
-        // für alle Fälle
-        $level = RexStanUserConfig::getLevel();
-        $paths = RexStanUserConfig::getPaths();
-        $phpVersion = RexStanUserConfig::getPhpVersion();
-        $includes = RexStanUserConfig::getIncludes();
-    
-        foreach ($this->getSaveElements() as $fieldsetElements) {
-            foreach ($fieldsetElements as $element) {
-                // read-only-fields nicht speichern
-                if ($element->isReadOnly()) {
-                    continue;
-                }
-
-                $fieldName = $element->getFieldName();
-                $fieldValue = $element->getSaveValue();
-
-                if (is_string($fieldValue)) {
-                    $fieldValue = trim($fieldValue);
-                }
-
-                switch ($fieldName) {
-                    // Zunächst die phpstan-Parameter auslesen und ggf aufbereiten
-                    case 'level':
-                        $level = (int) $fieldValue;
-                        break;
-                    case 'paths':
-                        $paths = array_filter(explode('|', trim((string) $fieldValue, '|')), 'strlen'); // String |x|y| rückumwandeln in [x,y]
-                        break;
-                    case 'phpVersion':
-                        $phpVersion = (int) $fieldValue;
-                        break;
-                    case 'includes':
-                        $includes = array_filter(explode('|', trim((string) $fieldValue, '|')), 'strlen'); // String |x|y| rückumwandeln in [x,y]
-                        break;
-
-                        // Default: als rex_config-Wert behandeln
-                    default:
-                        rex_config::set('rexstan', $fieldName, $fieldValue);
-                }
-            }
-        }
-
-        // Für die phpstan-Konfigurationseinträge: separat sichern
-        RexStanUserConfig::save($level, $paths, $includes, $phpVersion);
-        
-        // Just a notification via EP
-        rex_extension::registerPoint(new rex_extension_point('REXSTAN_SETTINGS_SAVED', '', []));
-
-        return true;
+        return $form;
     }
 }

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -75,11 +75,11 @@ final class RexStanSettings extends rex_config_form
      * @var array<string>
      */
     private static $phpVersionList = [
-        70300 => '7.3 [Mindestanforderung für REDAXO]',
-        70400 => '7.4',
-        80000 => '8.0',
-        80100 => '8.1',
-        80200 => '8.2',
+       70333 => '7.3 [Mindestanforderung für REDAXO]',
+       70430 => '7.4',
+       80022 => '8.0',
+       80109 => '8.1',
+       80200 => '8.2',
     ];
 
     /**

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -106,7 +106,7 @@ final class RexStanSettings
 
         $field = $form->addSelectField('phpversion', null, ['class' => 'form-control selectpicker']);
         $field->setLabel('PHP-Version');
-        $field->setNotice('Referenz-Version für die Code-Analyse');
+        $field->setNotice('<a href="https://phpstan.org/config-reference#phpversion">Referenz PHP-Version für die Code-Analyse</a>');
         $select = $field->getSelect();
         $select->addOptions($phpVersions);
 

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -1,31 +1,4 @@
 <?php
-/**
- * Formular-Klasse basierend auf rex_config_form mit folgenden Anpassungen:.
- *
- *   - class->getValue()
- *     Daten einlesen für ausgewählte Felder aus phpstan-Konfigurationsdateien
- *       a) user_config.neon
- *       b) default_config.neon (= Fallback)
- *     Für alle anderen via rex_config
- *   - class->save()
- *     Daten werden für ausgewählte Felder in user_config.neon gespeichert.
- *     Alle anderen via rex_config
- *   - class->init()
- *     Baut die Eingabefelder in das Formular ein
- *     Bereitet Daten für die Felder auf
- *
- * Immer mal wieder anzupassende Auswahllisten (z.B. phpVersionen, Extensons)
- * sind im vorderen Teil der Klasse zu finden. Init() bereitet daraus
- * Selects auf.
- *
- * Formularausgabe:
- *      $form = RexStanSettings::factory( 'rexstan' );
- *      $fragment = new \rex_fragment();
- *      $fragment->setVar('class', 'edit', false);
- *      $fragment->setVar('title', 'titel', false);
- *      $fragment->setVar('body', $form->get(), false);
- *      echo $fragment->parse('core/page/section.php');.
- */
 
 namespace redaxo\phpstan;
 

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -194,6 +194,13 @@ final class RexStanSettings extends rex_config_form
      */
     protected function save(): bool
     {
+    
+        // für alle Fälle
+        $level = RexStanUserConfig::getLevel();
+        $paths = RexStanUserConfig::getPaths();
+        $phpVersion = RexStanUserConfig::getPhpVersion();
+        $includes = RexStanUserConfig::getIncludes();
+    
         foreach ($this->getSaveElements() as $fieldsetElements) {
             foreach ($fieldsetElements as $element) {
                 // read-only-fields nicht speichern

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -37,7 +37,7 @@ final class RexStanSettings
      * @var array<int, string>
      */
     private static $phpVersionList = [
-        70333 => '7.3.x [Mindestanforderung für REDAXO    ]',
+        70333 => '7.3.x [Mindestanforderung für REDAXO]',
         70430 => '7.4.x',
         80022 => '8.0.x',
         80109 => '8.1.x',

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -116,12 +116,22 @@ final class RexStanSettings extends rex_config_form
 
         /**
          * Die aktuelle PHP-Version des Servers (SAPI) markieren.
+         * Die aktuelle PHP-Version in Terminal/Konsole (CLI) markieren
          */
 
-        $version = (int) (PHP_VERSION_ID / 100) * 100;
+        $sapiVersion = (int) (PHP_VERSION_ID / 100);
+        $cliVersion = (int) shell_exec('php -r \'echo PHP_VERSION_ID;\'');
+        $cliVersion = (int) ($cliVersion/100);
+
         $phpVersions = self::$phpVersionList;
-        if (isset($phpVersions[$version])) {
-            $phpVersions[$version] .= ' [aktuelle Webserver-Version (SAPI)]';
+        foreach( $phpVersions as $key=>&$label ) {
+            $key = (int) $key/100;
+            if( $key === $sapiVersion) {
+                $label .= ' [aktuelle Webserver-Version (SAPI)]';
+            }
+            if( $key === $cliVersion) {
+                $label .= ' [aktuelle Konsolen-Version (CLI)]';
+            }
         }
 
         $field = $this->addInputField('number', 'level', null, ['class' => 'form-control', 'min' => 0, 'max' => 9]);

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * Formular-Klasse basierend auf rex_config_form mit folgenden Anpassungen:.
+ *
+ *   - class->getValue()
+ *     Daten einlesen für ausgewählte Felder aus phpstan-Konfigurationsdateien
+ *       a) user_config.neon
+ *       b) default_config.neon (= Fallback)
+ *     Für alle anderen via rex_config
+ *   - class->save()
+ *     Daten werden für ausgewählte Felder in user_config.neon gespeichert.
+ *     Alle anderen via rex_config
+ *   - class->init()
+ *     Baut die Eingabefelder in das Formular ein
+ *     Bereitet Daten für die Felder auf
+ *
+ * Immer mal wieder anzupassende Auswahllisten (z.B. phpVersionen, Extensons)
+ * sind im vorderen Teil der Klasse zu finden. Init() bereitet daraus
+ * Selects auf.
+ *
+ * Formularausgabe:
+ *      $form = RexStanSettings::factory( 'rexstan' );
+ *      $fragment = new \rex_fragment();
+ *      $fragment->setVar('class', 'edit', false);
+ *      $fragment->setVar('title', 'titel', false);
+ *      $fragment->setVar('body', $form->get(), false);
+ *      echo $fragment->parse('core/page/section.php');.
+ */
+
+namespace redaxo\phpstan;
+
+use rex_addon;
+use rex_config;
+use rex_config_form;
+use rex_path;
+use RexStanUserConfig;
+
+use function is_string;
+
+final class RexStanSettings extends rex_config_form
+{
+    /**
+     * Listen der derzeit verfügbaren phpstan-Extensions ... ['label' => 'pfad_im_addon'].
+     *
+     * @var array<string>
+     */
+    private static $phpstanExtensions = [
+        'Bleeding-Edge' => 'vendor/phpstan/phpstan/conf/bleedingEdge.neon',
+        'Strict-Mode' => 'vendor/phpstan/phpstan-strict-rules/rules.neon',
+        'Deprecation Warnings' => 'vendor/phpstan/phpstan-deprecation-rules/rules.neon',
+        'PHPUnit' => 'vendor/phpstan/phpstan-phpunit/rules.neon',
+        'phpstan-dba' => 'lib/phpstan-dba.neon',
+        'cognitive complexity' => 'lib/cognitive-complexity.neon',
+    ];
+
+    /**
+     * ... und der Links zu Erläuterungen. ['label' => 'url'].
+     *
+     * @var array<string>
+     */
+    private static $phpstanExtensionDocLinks = [
+        'Bleeding-Edge' => 'https://phpstan.org/blog/what-is-bleeding-edge',
+        'Strict-Mode' => 'https://github.com/phpstan/phpstan-strict-rules#readme',
+        'Deprecation Warnings' => 'https://github.com/phpstan/phpstan-deprecation-rules#readme">Deprecation-Warnings',
+        'PHPUnit' => 'https://github.com/phpstan/phpstan-phpunit#readme">PHPUnit',
+        'phpstan-dba' => 'https://staabm.github.io/archive.html#phpstan-dba',
+        'cognitive complexity' => 'https://tomasvotruba.com/blog/2018/05/21/is-your-code-readable-by-humans-cognitive-complexity-tells-you/',
+    ];
+
+    /**
+     * Liste der derzeit relevanten PHP-Versionen. [versionId => 'label'].
+     *
+     * @var array<string>
+     */
+    private static $phpVersionList = [
+        70300 => '7.3 [Mindestanforderung für REDAXO]',
+        70400 => '7.4',
+        80000 => '8.0',
+        80100 => '8.1',
+        80200 => '8.2',
+    ];
+
+    /**
+     * Initialisiert das Formular.
+     *
+     * @return void
+     */
+    public function init()
+    {
+        $extensions = [];
+        foreach (self::$phpstanExtensions as $label => $path) {
+            $extensions[rex_path::addon('rexstan', $path)] = $label;
+        }
+
+        $extensionLinks = [];
+        foreach (self::$phpstanExtensionDocLinks as $label => $link) {
+            $extensionLinks[] = '<a href="'.$link.'">'.$label.'</a>';
+        }
+
+        /**
+         * Liste der analysierbaren Verzeichnisse (= Addons) ermitteln
+         * Sonderfall: developer-Addon.
+         */
+
+        $scanTargets = [];
+        foreach (rex_addon::getAvailableAddons() as $availableAddon) {
+            $scanTargets[$availableAddon->getPath()] = $availableAddon->getName();
+
+            if ('developer' === $availableAddon->getName() && class_exists(rex_developer_manager::class)) {
+                $scanTargets[rex_developer_manager::getBasePath() .'/modules/'] = 'developer: modules';
+                $scanTargets[rex_developer_manager::getBasePath() .'/templates/'] = 'developer: templates';
+            }
+        }
+
+        /**
+         * Die aktuelle PHP-Version des Servers (SAPI) markieren.
+         */
+
+        $version = (int) (PHP_VERSION_ID / 100) * 100;
+        $phpVersions = self::$phpVersionList;
+        if (isset($phpVersions[$version])) {
+            $phpVersions[$version] .= ' [aktuelle Webserver-Version (SAPI)]';
+        }
+
+        $field = $this->addInputField('number', 'level', null, ['class' => 'form-control', 'min' => 0, 'max' => 9]);
+        $field->setLabel('Level');
+        $field->setNotice('0 is the loosest and 9 is the strictest - <a href="https://phpstan.org/user-guide/rule-levels">see PHPStan Rule Levels</a>');
+
+        $field = $this->addSelectField('paths', null, ['class' => 'form-control selectpicker', 'data-live-search' => 'true', 'required' => 'required']); // die Klasse selectpicker aktiviert den Selectpicker von Bootstrap
+        $field->setAttribute('multiple', 'multiple');
+        $field->setLabel('AddOns');
+        $field->setNotice('AddOns, die untersucht werden sollen');
+        $select = $field->getSelect();
+        $select->addOptions($scanTargets);
+
+        $field = $this->addSelectField('includes', null, ['class' => 'form-control selectpicker']);
+        $field->setAttribute('multiple', 'multiple');
+        $field->setLabel('PHPStan Extensions');
+        $field->setNotice('Weiterlesen bzgl. der verf&uuml;gbaren Extensions: '.implode(', ', $extensionLinks));
+        $select = $field->getSelect();
+        $select->addOptions($extensions);
+
+        $field = $this->addSelectField('phpVersion', null, ['class' => 'form-control selectpicker']);
+        $field->setLabel('PHP-Version');
+        $field->setNotice('Referenz-Version für die Code-Analyse');
+        $select = $field->getSelect();
+        $select->addOptions($phpVersions);
+    }
+
+    /**
+     * Feldwerte abrufen aus userConf, defaultConf oder rex_config.
+     *
+     * Die Parent-Methode ruft ausschließlich Werte aus der Tabelle rex_config ab.
+     * Die überschriebene Methode versucht zunächst auf phpstan-Settings zuzugreifen.
+     * Kommt der NAme nicht in der Liste (switch..) vor, wird unter dem Namen auf
+     * rex_config zurückgegriffen.
+     *
+     * @param string $name  Der Feldname
+     *
+     * @return mixed  Der zum Feld gehörende Wert; default=''
+     */
+    protected function getValue($name)
+    {
+        switch ($name) {
+            // Zunächst die phpstan-Parameter abrufen
+            case 'level':
+                $value = RexStanUserConfig::getLevel();
+                break;
+            case 'paths':
+                $value = RexStanUserConfig::getPaths();
+                break;
+            case 'phpVersion':
+                $value = RexStanUserConfig::getPhpVersion();
+                break;
+            case 'includes':
+                $value = RexStanUserConfig::getIncludes();
+                break;
+
+                // Default: als rex_config-Wert behandeln
+            default:
+                $value = parent::getValue($name);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Speichert die Änderungen des Settings-Formuars.
+     *
+     * Die Parent-Methode schreibt die Werte in die Tabelle rex_config.
+     * Hier werden zunächst die für phpstan vorgesehenen Werte abgefangen und in die $userConf
+     * übertragen. Am Ende wird $userConf auf die Platte geschrieben.
+     * Alle übrigen Felder werden als rex_config gespeichert.
+     */
+    protected function save(): bool
+    {
+        foreach ($this->getSaveElements() as $fieldsetElements) {
+            foreach ($fieldsetElements as $element) {
+                // read-only-fields nicht speichern
+                if ($element->isReadOnly()) {
+                    continue;
+                }
+
+                $fieldName = $element->getFieldName();
+                $fieldValue = $element->getSaveValue();
+
+                if (is_string($fieldValue)) {
+                    $fieldValue = trim($fieldValue);
+                }
+
+                switch ($fieldName) {
+                    // Zunächst die phpstan-Parameter auslesen und ggf aufbereiten
+                    case 'level':
+                        $level = (int) $fieldValue;
+                        break;
+                    case 'paths':
+                        $paths = array_filter(explode('|', trim((string) $fieldValue, '|')), 'strlen'); // String |x|y| rückumwandeln in [x,y]
+                        break;
+                    case 'phpVersion':
+                        $phpVersion = (int) $fieldValue;
+                        break;
+                    case 'includes':
+                        $includes = array_filter(explode('|', trim((string) $fieldValue, '|')), 'strlen'); // String |x|y| rückumwandeln in [x,y]
+                        break;
+
+                        // Default: als rex_config-Wert behandeln
+                    default:
+                        rex_config::set('rexstan', $fieldName, $fieldValue);
+                }
+            }
+        }
+
+        // Für die phpstan-Konfigurationseinträge: separat sichern
+        RexStanUserConfig::save($level, $paths, $includes, $phpVersion);
+
+        return true;
+    }
+}

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -106,7 +106,7 @@ final class RexStanSettings
 
         $field = $form->addSelectField('phpversion', null, ['class' => 'form-control selectpicker']);
         $field->setLabel('PHP-Version');
-        $field->setNotice('<a href="https://phpstan.org/config-reference#phpversion">Referenz PHP-Version für die Code-Analyse</a>');
+        $field->setNotice('<a href="https://phpstan.org/config-reference#phpversion">Referenz PHP-Version</a> für die Code-Analyse');
         $select = $field->getSelect();
         $select->addOptions($phpVersions);
 

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -239,6 +239,9 @@ final class RexStanSettings extends rex_config_form
 
         // Für die phpstan-Konfigurationseinträge: separat sichern
         RexStanUserConfig::save($level, $paths, $includes, $phpVersion);
+        
+        // Just a notification via EP
+        rex_extension::registerPoint(new rex_extension_point('REXSTAN_SETTINGS_SAVED', '', []));
 
         return true;
     }

--- a/lib/RexStanUserConfig.php
+++ b/lib/RexStanUserConfig.php
@@ -42,14 +42,14 @@ final class RexStanUserConfig
     {
         self::ensureDefaultConfLoaded();
         self::ensureUserConfLoaded();
-        return (int) self::$userConf['parameters']['level'] ?? self::$defaultConf['parameters']['level'];
+        return (int) (self::$userConf['parameters']['level'] ?? self::$defaultConf['parameters']['level'] );
     }
 
     public static function getPhpVersion(): int
     {
         self::ensureDefaultConfLoaded();
         self::ensureUserConfLoaded();
-        return (int) self::$userConf['parameters']['phpVersion'] ?? self::$defaultConf['parameters']['phpVersion'];
+        return (int) (self::$userConf['parameters']['phpVersion'] ?? self::$defaultConf['parameters']['phpVersion']);
     }
 
     /**

--- a/lib/RexStanUserConfig.php
+++ b/lib/RexStanUserConfig.php
@@ -47,7 +47,7 @@ final class RexStanUserConfig
         $neon = self::readUserConfig();
         $userConf = rex_string::yamlDecode($neon);
 
-        $neon = rex_file::get(rex_path::addon('rexstan', 'default-config.neon'), []);
+        $neon = rex_file::get(rex_path::addon('rexstan', 'default-config.neon'), '');
         $defaultConf = rex_string::yamlDecode($neon);
 
         return $userConf + $defaultConf;

--- a/lib/RexStanUserConfig.php
+++ b/lib/RexStanUserConfig.php
@@ -11,7 +11,7 @@ final class RexStanUserConfig
     /**
      * @var array<mixed>  Cache: Array mit der User-Konfiguration; null = noch nicht eingelesen
      */
-    private static $userConf;
+    private static $userConf = [];
 
     /**
      * @var array<mixed>  Cache: Array mit der Default-Konfiguration; null = noch nicht eingelesen

--- a/lib/RexStanUserConfig.php
+++ b/lib/RexStanUserConfig.php
@@ -23,12 +23,12 @@ final class RexStanUserConfig
 
     public static function getLevel(): int
     {
-        return self::getConfig()['parameters']['level'] ?? 0;
+        return (int) (self::getConfig()['parameters']['level']);
     }
 
     public static function getPhpVersion(): int
     {
-        return self::getConfig()['parameters']['phpVersion'] ?? 0;
+        return (int) (self::getConfig()['parameters']['phpVersion']);
     }
 
     /**

--- a/lib/RexStanUserConfig.php
+++ b/lib/RexStanUserConfig.php
@@ -16,7 +16,7 @@ final class RexStanUserConfig
     /**
      * @var array<mixed>  Cache: Array mit der Default-Konfiguration; null = noch nicht eingelesen
      */
-    private static $defaultConf;
+    private static $defaultConf = [];
 
     /**
      * @param array<string> $paths

--- a/lib/RexStanUserConfig.php
+++ b/lib/RexStanUserConfig.php
@@ -3,108 +3,69 @@
 final class RexStanUserConfig
 {
     /**
-     * Dateinamen.
-     */
-    private const DEF_CONFIG = 'default-config.neon';
-    private const USR_CONFIG = 'user-config.neon';
-
-    /**
-     * @var array<mixed>  Cache: Array mit der User-Konfiguration; null = noch nicht eingelesen
-     */
-    private static $userConf = [];
-
-    /**
-     * @var array<mixed>  Cache: Array mit der Default-Konfiguration; null = noch nicht eingelesen
-     */
-    private static $defaultConf = [];
-
-    /**
-     * @param array<string> $paths
-     * @param array<string> $includes
+     * @param list<string> $paths
+     * @param list<string> $includes
      *
      * @return void
      */
     public static function save(int $level, array $paths, array $includes, int $phpVersion)
     {
-        self::ensureUserConfLoaded();
-
-        self::$userConf['includes'] = $includes;
-        self::$userConf['parameters']['level'] = $level;
-        self::$userConf['parameters']['paths'] = $paths;
-        self::$userConf['parameters']['phpVersion'] = $phpVersion;
+        $file = [];
+        $file['includes'] = $includes;
+        $file['parameters']['level'] = $level;
+        $file['parameters']['paths'] = $paths;
+        $file['parameters']['phpVersion'] = $phpVersion;
 
         $prefix = "# rexstan auto generated file - do not edit, rename or remove\n\n";
 
-        rex_file::put(self::getUserConfigPath(), $prefix . rex_string::yamlEncode(self::$userConf, 3));
+        rex_file::put(self::getUserConfigPath(), $prefix . rex_string::yamlEncode($file, 3));
     }
 
     public static function getLevel(): int
     {
-        self::ensureDefaultConfLoaded();
-        self::ensureUserConfLoaded();
-        return (int) (self::$userConf['parameters']['level'] ?? self::$defaultConf['parameters']['level'] );
+        return self::getConfig()['parameters']['level'] ?? 0;
     }
 
     public static function getPhpVersion(): int
     {
-        self::ensureDefaultConfLoaded();
-        self::ensureUserConfLoaded();
-        return (int) (self::$userConf['parameters']['phpVersion'] ?? self::$defaultConf['parameters']['phpVersion']);
+        return self::getConfig()['parameters']['phpVersion'] ?? 0;
     }
 
     /**
-     * @return array<string>
+     * @return list<string>
      */
     public static function getPaths(): array
     {
-        self::ensureDefaultConfLoaded();
-        self::ensureUserConfLoaded();
-        return self::$userConf['parameters']['paths'] ?? self::$defaultConf['parameters']['paths'];
+        return self::getConfig()['parameters']['paths'] ?? [];
     }
 
     /**
-     * @return array<string>
+     * @return array<string, mixed>
      */
-    public static function getIncludes(): array
+    private static function getConfig(): array
     {
-        self::ensureDefaultConfLoaded();
-        self::ensureUserConfLoaded();
-        return self::$userConf['includes'] ?? self::$defaultConf['includes'];
+        $neon = self::readUserConfig();
+        $userConf = rex_string::yamlDecode($neon);
+
+        $neon = rex_file::get(rex_path::addon('rexstan', 'default-config.neon'), []);
+        $defaultConf = rex_string::yamlDecode($neon);
+
+        return $userConf + $defaultConf;
     }
 
-    /**
-     * liefert den Pfadnamen der Default-Settings ('default-config.neon' im Addon-Verzeichnis).
-     */
-    private static function getDefaultConfigPath(): string
+    private static function readUserConfig(): string
     {
-        return rex_path::addon('rexstan', self::DEF_CONFIG);
+        $neon = rex_file::get(self::getUserConfigPath());
+
+        if (null === $neon) {
+            throw new \RuntimeException('Unable to read userconfig');
+        }
+
+        return $neon;
     }
 
-    /**
-     * liefert den Pfadnamen der User-Settings ('user-config.neon' im Data-Verzeichnis).
-     */
     private static function getUserConfigPath(): string
     {
-        return rex_path::addonData('rexstan', self::USR_CONFIG);
-    }
-
-    /**
-     * Stellt sicher, dass die User-Konfigurationsdatei geladen ist.
-     */
-    private static function ensureUserConfLoaded(): void
-    {
-        if (null === self::$userConf) {
-            self::$userConf = rex_file::getConfig(self::getUserConfigPath(), []);
-        }
-    }
-
-    /**
-     * Stellt sicher, dass die Default-Konfigurationsdatei geladen ist.
-     */
-    private static function ensureDefaultConfLoaded(): void
-    {
-        if (null === self::$defaultConf) {
-            self::$defaultConf = rex_file::getConfig(self::getDefaultConfigPath(), []);
-        }
+        return rex_addon::get('rexstan')->getDataPath('user-config.neon');
     }
 }

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -16,7 +16,7 @@ if (rex_post($form_name . '_save')) {
     $level = (int) $postData['level'];
     $addonPaths = $postData['addons'] ?? [];
     $extensions = $postData['extensions'] ?? [];
-    $phpversion = (int) $postData['phpversion'] ?? [];
+    $phpversion = (int) $postData['phpversion'];
 
     $paths = [];
     foreach ($addonPaths as $addonPath) {

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -1,10 +1,7 @@
 <?php
-$form = redaxo\phpstan\RexStanSettings::factory('rexstan');
-$faqUrl = rex_url::backendPage('rexstan/faq');
 
-/**
- * Formularcode als Section via Fragment ausgeben.
- */
+$form = redaxo\phpstan\RexStanSettings::createForm();
+$faqUrl = rex_url::backendPage('rexstan/faq');
 
 $fragment = new rex_fragment();
 $fragment->setVar('options', '<a class="btn btn-info" href="'. $faqUrl .'">Weitere Informationen in den FAQ</a>', false);
@@ -12,3 +9,24 @@ $fragment->setVar('class', 'edit', false);
 $fragment->setVar('title', 'Settings', false);
 $fragment->setVar('body', $form->get(), false);
 echo $fragment->parse('core/page/section.php');
+
+$form_name = $form->getName();
+if (rex_post($form_name . '_save')) {
+    $postData = rex_post($form_name);
+    $level = (int) $postData['level'];
+    $addonPaths = $postData['addons'] ?? [];
+    $extensions = $postData['extensions'] ?? [];
+    $phpversion = (int) $postData['phpversion'] ?? [];
+
+    $paths = [];
+    foreach ($addonPaths as $addonPath) {
+        $paths[] = $addonPath;
+    }
+
+    $includes = [];
+    foreach ($extensions as $extensionPath) {
+        $includes[] = $extensionPath;
+    }
+
+    RexStanUserConfig::save($level, $paths, $includes, $phpversion);
+}

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Konfigurationsseite des Addons / Settings.
- *
- * Das Formular wird mit der Form-Klasse RexStanSettings, basierend auf rex_config_form, aufsetzt.
- * Die Parametriesierung und der Formularaufbaue (Felder) ist komplett in RexStanSettings.php zu finden
-*/
-
 $form = redaxo\phpstan\RexStanSettings::factory('rexstan');
 $faqUrl = rex_url::backendPage('rexstan/faq');
 
@@ -14,7 +7,7 @@ $faqUrl = rex_url::backendPage('rexstan/faq');
  */
 
 $fragment = new rex_fragment();
-$fragment->setVar('options', '<a class="btn btn-info" href="'. rex_url::backendPage('rexstan/faq') .'">Weitere Informationen in den FAQ</a>', false);
+$fragment->setVar('options', '<a class="btn btn-info" href="'. $faqUrl .'">Weitere Informationen in den FAQ</a>', false);
 $fragment->setVar('class', 'edit', false);
 $fragment->setVar('title', 'Settings', false);
 $fragment->setVar('body', $form->get(), false);

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -1,61 +1,21 @@
 <?php
+/**
+ * Konfigurationsseite des Addons / Settings.
+ *
+ * Das Formular wird mit der Form-Klasse RexStanSettings, basierend auf rex_config_form, aufsetzt.
+ * Die Parametriesierung und der Formularaufbaue (Felder) ist komplett in RexStanSettings.php zu finden
+*/
 
-$form = rex_config_form::factory('rexstan');
+$form = redaxo\phpstan\RexStanSettings::factory('rexstan');
+$faqUrl = rex_url::backendPage('rexstan/faq');
 
-$field = $form->addInputField('number', 'level', RexStanUserConfig::getLevel(), ['class' => 'form-control', 'min' => 0, 'max' => 9]);
-$field->setLabel('Level');
-$field->setNotice('0 is the loosest and 9 is the strictest - <a href="https://phpstan.org/user-guide/rule-levels">see PHPStan Rule Levels</a>');
-
-$field = $form->addSelectField('addons', RexStanUserConfig::getPaths(), ['class' => 'form-control selectpicker', 'data-live-search' => 'true']); // die Klasse selectpicker aktiviert den Selectpicker von Bootstrap
-$field->setAttribute('multiple', 'multiple');
-$field->setLabel('AddOns');
-$field->setNotice('AddOns die untersucht werden sollen');
-$select = $field->getSelect();
-
-foreach (rex_addon::getAvailableAddons() as $availableAddon) {
-    $select->addOption($availableAddon->getName(), $availableAddon->getPath());
-
-    if ('developer' === $availableAddon->getName() && class_exists(rex_developer_manager::class)) {
-        $select->addOption('developer: modules', rex_developer_manager::getBasePath() .'/modules/');
-        $select->addOption('developer: templates', rex_developer_manager::getBasePath() .'/templates/');
-    }
-}
-
-$field = $form->addSelectField('extensions', RexStanUserConfig::getIncludes(), ['class' => 'form-control selectpicker']);
-$field->setAttribute('multiple', 'multiple');
-$field->setLabel('PHPStan Extensions');
-$field->setNotice('Weiterlesen bzgl. der verf&uuml;gbaren Extensions: <a href="https://phpstan.org/blog/what-is-bleeding-edge">Bleeding-Edge</a>, <a href="https://github.com/phpstan/phpstan-strict-rules#readme">Strict-Mode</a>, <a href="https://github.com/phpstan/phpstan-deprecation-rules#readme">Deprecation-Warnings</a>, <a href="https://github.com/phpstan/phpstan-phpunit#readme">PHPUnit</a>, <a href="https://staabm.github.io/archive.html#phpstan-dba">phpstan-dba</a>, <a href="https://tomasvotruba.com/blog/2018/05/21/is-your-code-readable-by-humans-cognitive-complexity-tells-you/">cognitive complexity</a>');
-$select = $field->getSelect();
-
-$select->addOption('Bleeding-Edge', realpath(__DIR__.'/../vendor/phpstan/phpstan/conf/bleedingEdge.neon'));
-$select->addOption('Strict-Mode', realpath(__DIR__.'/../vendor/phpstan/phpstan-strict-rules/rules.neon'));
-$select->addOption('Deprecation Warnings', realpath(__DIR__.'/../vendor/phpstan/phpstan-deprecation-rules/rules.neon'));
-$select->addOption('PHPUnit', realpath(__DIR__.'/../vendor/phpstan/phpstan-phpunit/rules.neon'));
-$select->addOption('phpstan-dba', realpath(__DIR__.'/../lib/phpstan-dba.neon'));
-$select->addOption('cognitive complexity', realpath(__DIR__.'/../lib/cognitive-complexity.neon'));
+/**
+ * Formularcode als Section via Fragment ausgeben.
+ */
 
 $fragment = new rex_fragment();
-$fragment->setVar('heading', '<i>Einstellungen werden <a href="'. rex_url::backendPage('rexstan/faq') .'">im FAQ erklärt</a></i>', false);
+$fragment->setVar('options', '<a class="btn btn-info" href="'. rex_url::backendPage('rexstan/faq') .'">Weitere Informationen in den FAQ</a>', false);
 $fragment->setVar('class', 'edit', false);
 $fragment->setVar('title', 'Settings', false);
 $fragment->setVar('body', $form->get(), false);
 echo $fragment->parse('core/page/section.php');
-
-$form_name = $form->getName();
-if (rex_post($form_name . '_save')) {
-    $postData = rex_post($form_name);
-    $addonPaths = $postData['addons'] ?? [];
-    $extensions = $postData['extensions'] ?? [];
-
-    $paths = [];
-    foreach ($addonPaths as $addonPath) {
-        $paths[] = $addonPath;
-    }
-
-    $includes = [];
-    foreach ($extensions as $extensionPath) {
-        $includes[] = $extensionPath;
-    }
-
-    RexStanUserConfig::save((int) $postData['level'], $paths, $includes);
-}


### PR DESCRIPTION
Hier der PR, um am Ende die PHP-Auswahl zu ermöglichen. Er umfasst gleich ein paar Aspekte mit

### pages/settings.php

- Das Settings-Formular wird nun mit `RexStanSettings extends rex_config_form` erzeugt und verwaltet. Die neue Klasse unterstützt die .neon-Dateien im Addon. 
- Der Aufbau des Formulars ist jetzt in `RexStanSettings::init()` verschoben. So muss bei weiteren Änderungen der Formularfelder nur eine Datei angefasst werden; `settings.php`kann bleiben wie sie ist.
- `settings.php` ist reduziert auf
  - Formular-Instanz anlegen
  - Section-Fragment aufbauen
  - Formular via Fragment anzeigen 

### lib/RexStanSettings.php

- Formularklasse basierend auf `rex_config_form`, aber mit im Wesentlichen drei geänderten Methoden:
  - `init()`: baut das Formular auf, indem die Felder hinzugefügt werden
  - `getValue($name)`: liefert den Wert zum Feldnamen. Für ausgewählte Feldnamen, die Werte aus .neon-Dateien holen, erfolgt ein zielgerichter Datenabruf. Alle anderen Feldnamen werden wie in `rex_config_form`-Formularen üblich als Felder aus `rex_config` behandelt.
  - `save()`: Speichert die Formularwerte. Für ausgewählte Feldnamen, die Werte aus .neon-Dateien enthalten, wird nach user-config.neon gespeichert. Für alle anderen Feldnamen werden die Werte wie via `rex_config` gepeichert.
- Inhalte der Select-Felder (Addons, Extensions bzw. PHP-Versionen) werden am Anfang der Klasse als Array bereitgestelt. Schnell auffindbar und änderbar.
- Neues Feld für phpVersion mit Auswahl 7.3 bis 8.2.
![image](https://user-images.githubusercontent.com/10065904/184499981-d0074bcb-7a9b-4449-82f2-e454c29a58b8.png)
- EP REXSTAN_SETTINGS_SAVED nach dem Speichern ermöglicht eigene Folgeaktionen. Beispiel: im Editor die Code-Prüfung auf dieselbe Version einstellen (VSCode mit PHP-Intelephense: in settings.json `"intelephense.environment.phpVersion": "x.y.0"` setzen)
 

### lib/RexStanUserConfig.php

- Berücksichtig nun auch default-config.neon beim Lesen.
- Liest einmalig beim ersten Zugriff (getXxxx) default-config.neon und user-config.neon in static-Variablen ein, Cached also für weitere Zugriffe.
- Lesen (getXxxx) entmimmt den Werrt zunächst aus user-config.neon und, wenn nicht gefunden, aus default-config.neon.
- Schreiben erfolgt ausschließlich nach user-config.neon.
- Schreiben überschreibt nur Werte, die von RexStanUserConfig verwaltet werden: alle anderen Einträge bleiben erhalten.
- Unterstützt als vierten Wert phpVersion

### weitere kleinere Anpassungen on the fly

- Der Link zur FAQ-Seite erschien mir schlecht lesbar. Durch einen Button ersetzt (btn-info).
  ![image](https://user-images.githubusercontent.com/10065904/184500222-a61d52bb-6b69-43bc-89cf-e3c0b663c374.png)
- Select-Feld "paths" für die Addon-Auswahl auf "required" gesetzt, da mindestens ein Addon ausgewählt werden muss. Dann fällt es nicht erst auf, wenn die Analyse mangels Addon-paths gegen die Wand läuft. 
