### PR TITLE
remove unused css

### DIFF
--- a/assets/rexstan.css
+++ b/assets/rexstan.css
@@ -1,13 +1,3 @@
-.rexstan-error-file span {
-    color: rgb(119, 119, 119);
-}
-
-@media (prefers-color-scheme: dark) {
-    .rexstan-error-file span {
-        color: rgba(255, 255, 255, 0.45);
-    }
-}
-
 .rexstan-achievement {
     font-size: 50px;
     height: 100px;


### PR DESCRIPTION
.rexstan-error-file wird nicht mehr benötigt. Ist bei #82 durch das neue Design rausgefallen.