### PR TITLE
Bugfix: Link zum Editor um angehängte Texte bereinigen

### DIFF
--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -119,6 +119,7 @@ if (
 
     foreach ($phpstanResult['files'] as $file => $fileResult) {
         $shortFile = str_replace($basePath, '', $file);
+        $linkFile = preg_replace('/\s\(in context.*?$/','',$file);
         $title = '<i class="rexstan-open fa fa-folder-o"></i>'.
                  '<i class="rexstan-closed fa fa-folder-open-o"></i> '.
                  '<span class="text-muted">'.rex_escape(dirname($shortFile)).DIRECTORY_SEPARATOR.'</span>'
@@ -133,7 +134,7 @@ if (
             $content .= '<li class="list-group-item rexstan-message">';
             $content .= '<span class="rexstan-linenumber">' .sprintf('%5d', $message['line']).':</span>';
             $error = rex_escape($message['message']);
-            $url = rex_editor::factory()->getUrl($file, $message['line']);
+            $url = rex_editor::factory()->getUrl($linkFile, $message['line']);
             if ($url) {
                 $error = '<a href="'. $url .'">'. rex_escape($message['message']) .'</a>';
             }


### PR DESCRIPTION
Eigentlich wird ja der Dateiname (Key im Array `$phpstanResult['files']`) auch so im Editor-Link benutzt. Wie sich herausstellt gibt es auch Keys, die zusätzlich zum Dateinamen weitere Informationen enthalten.

![grafik](https://user-images.githubusercontent.com/10065904/191331332-a72fbe14-abe6-42cd-a7e9-f144d7422d2c.png)

Der daraus generierte Editor-Link führt folglich zu einem Aufruffehler. Um das Problem zu beheben, wid mit diesem PR der Teil ` (in context ....` aus dem Link entfernt.