### PR TITLE
fix false-positive when comparing `'rex_'` with `rex::getTablePrefix()`

### DIFF
--- a/lib/extension/RexClassDynamicReturnTypeExtension.php
+++ b/lib/extension/RexClassDynamicReturnTypeExtension.php
@@ -31,10 +31,6 @@ final class RexClassDynamicReturnTypeExtension implements DynamicStaticMethodRet
     {
         $name = strtolower($methodReflection->getName());
 
-        if ('gettableprefix' === $name) {
-            return new ConstantStringType('rex_');
-        }
-
         $args = $methodCall->getArgs();
         if (count($args) < 1) {
             return null;

--- a/tests/data/sql-get-value.php
+++ b/tests/data/sql-get-value.php
@@ -59,3 +59,15 @@ function tableNamePrefix(): void
 
     assertType('string', $sql->getValue('rex_article.name'));
 }
+
+function tableNamePrefix(): void
+{
+    $sql = rex_sql::factory();
+    $sql->setQuery('
+            SELECT  name
+            FROM    ' . rex::getTablePrefix() . 'article
+            WHERE   id = 1
+            LIMIT   1
+        ');
+    assertType('string', $sql->getValue('rex_article.name'));
+}


### PR DESCRIPTION
closes https://github.com/FriendsOfREDAXO/rexstan/issues/143

depends on
- https://github.com/redaxo/redaxo/pull/5346
- https://github.com/staabm/phpstan-dba/pull/432