### PR TITLE
Addon-Auswahl auf Plugins erweitert

### DIFF
--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -93,7 +93,7 @@ final class RexStanSettings
         $select = $field->getSelect();
         foreach (rex_addon::getAvailableAddons() as $availableAddon) {
             $availablePlugins = $availableAddon->getAvailablePlugins();
-            $optGroup = 0 < count($availablePlugins) || 'developer' === $availableAddon->getName();
+            $optGroup = 0 < count($availablePlugins) || ('developer' === $availableAddon->getName() && class_exists(rex_developer_manager::class));
             if ($optGroup) {
                 $select->addOptgroup($availableAddon->getName());
             }

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -5,7 +5,10 @@ namespace redaxo\phpstan;
 use rex_addon;
 use rex_config;
 use rex_config_form;
+use rex_developer_manager;
 use rex_path;
+
+use function count;
 
 final class RexStanSettings
 {
@@ -90,18 +93,18 @@ final class RexStanSettings
         $select = $field->getSelect();
         foreach (rex_addon::getAvailableAddons() as $availableAddon) {
             $availablePlugins = $availableAddon->getAvailablePlugins();
-            $optGroup = 0 < count($availablePlugins) || 'developer' === $availableAddon->getName(); 
+            $optGroup = 0 < count($availablePlugins) || 'developer' === $availableAddon->getName();
             if ($optGroup) {
                 $select->addOptgroup($availableAddon->getName());
             }
-            $select->addOption($availableAddon->getName(),$availableAddon->getPath());
+            $select->addOption($availableAddon->getName(), $availableAddon->getPath());
             if ($optGroup) {
-                foreach( $availablePlugins as $availablePlugin ) {
-                    $select->addOption($availableAddon->getName() . ' ⇒ ' . $availablePlugin->getName(),$availablePlugin->getPath());
+                foreach ($availablePlugins as $availablePlugin) {
+                    $select->addOption($availableAddon->getName() . ' ⇒ ' . $availablePlugin->getName(), $availablePlugin->getPath());
                 }
                 if ('developer' === $availableAddon->getName()) {
-                    $select->addOption('developer: modules',\rex_developer_manager::getBasePath() .'/modules/');
-                    $select->addOption('developer: templates',\rex_developer_manager::getBasePath() .'/templates/');
+                    $select->addOption('developer: modules', rex_developer_manager::getBasePath() .'/modules/');
+                    $select->addOption('developer: templates', rex_developer_manager::getBasePath() .'/templates/');
                 }
                 $select->endOptgroup();
             }

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -93,7 +93,7 @@ final class RexStanSettings
         $select = $field->getSelect();
         foreach (rex_addon::getAvailableAddons() as $availableAddon) {
             $availablePlugins = $availableAddon->getAvailablePlugins();
-            $optGroup = 0 < count($availablePlugins) || ('developer' === $availableAddon->getName() && class_exists(rex_developer_manager::class));
+            $optGroup = 0 < count($availablePlugins) || 'developer' === $availableAddon->getName();
             if ($optGroup) {
                 $select->addOptgroup($availableAddon->getName());
             }
@@ -102,7 +102,7 @@ final class RexStanSettings
                 foreach ($availablePlugins as $availablePlugin) {
                     $select->addOption($availableAddon->getName() . ' ⇒ ' . $availablePlugin->getName(), $availablePlugin->getPath());
                 }
-                if ('developer' === $availableAddon->getName()) {
+                if ('developer' === $availableAddon->getName() && class_exists(rex_developer_manager::class)) {
                     $select->addOption('developer: modules', rex_developer_manager::getBasePath() .'/modules/');
                     $select->addOption('developer: templates', rex_developer_manager::getBasePath() .'/templates/');
                 }


### PR DESCRIPTION
Nur mal so als Vorschlag: Man könnte die Auswahl der Addons auch um die Auswahl der Plugins erweitern. Damit die Plugins als Gruppe im Select erscheinen, hab ich den Aufbau der Liste nicht mehr als simples addOptions, sondern baue im Select-Objekt Option-Groups. Der Code zum Zusammenstellen der Liste ist daher noch untern gewandert. 

Technisch ergibt sich kein Problem, wenn man sowohl das Addon als auch ein Plugin daraus anwählt. PhpStan nimmt die Dateien wohl nur einmal. Zumindest sind sie nur einmal in der Ergebnisliste.

<img width="1088" alt="grafik" src="https://user-images.githubusercontent.com/10065904/195511419-ec83d65f-e16b-471e-9278-443c6a228376.png">
