### PR TITLE
rename 'code complexity' to 'report mixed'

### DIFF
--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -21,7 +21,7 @@ final class RexStanSettings
         'PHPUnit' => 'vendor/phpstan/phpstan-phpunit/rules.neon',
         'phpstan-dba' => 'config/phpstan-dba.neon',
         'cognitive complexity' => 'config/cognitive-complexity.neon',
-        'code complexity' => 'config/code-complexity.neon',
+        'report mixed' => 'config/code-complexity.neon',
         'dead code' => 'config/dead-code.neon',
     ];
 


### PR DESCRIPTION
to disambiguate between 'cognitive complexity' and make it more obvious to the end user what the extension is doing