### PR TITLE
tmpDir angeben wg. Fehler auf Windows

### DIFF
--- a/default-config.neon
+++ b/default-config.neon
@@ -8,6 +8,8 @@ includes:
 parameters:
     level: 5
 
+    tmpDir: ../../../cache/addons/rextstan/phpstan
+
     excludePaths:
         - '*/vendor/*'
 


### PR DESCRIPTION
Hintergrund:

**PHP 7.4 / phpstan** 
verwendet als tmpDir `c:\users\USERNAME\Appdata\Local\` Da klappt auch alles einwandfrei da das User-Verzeichnis immer existiert. Alles gut!

**Bei PHP 8.0 + 8.1 + 8.2 / phpstan**
wird komischerweise fix der Pfad `c:\xampp\tmp` verwendet, und nicht der Windows-User-Pfad wie bei PHP 7.4

Plötlzich traten bei mir Fehler in rexstan unter PHP 8.x auf.  Dann habe ich erstmal analysiert wo eigentlich in welchem Temp-Verzeichnis die Workdateien ausgegeben werden.

Ich hatte noch einen alten Xampp auf dem System und den hatte ich gelöscht (c:\xampp). Daher ist dieses Verhalten bisher nicht aufgefallen. Und die Fehler habe ich natürlich auch nicht auf das Löschen des Verzeichnisses zurückgeführt da das schon ein paar Tage her war :((

Default ist bei meiner Entwicklungsumgebung noch PHP 7.4

Mit dieser Änderung werden die Dateien im REDAXO-Cache ausgegeben und werden so auch bei REDAXO Cache-Löschen entfernt.