### PR TITLE
Whoops vermeiden bei Baseline 0

### DIFF
--- a/lib/RexStan.php
+++ b/lib/RexStan.php
@@ -101,7 +101,7 @@ final class RexStan
         $baselineGlob = $dataDir.$configSignature.DIRECTORY_SEPARATOR.'*-summary.json';
         $htmlGraphPath = $dataDir.'baseline-graph.html';
 
-        self::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline', $stderrOutput, $exitCode);
+        self::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline --allow-empty-baseline', $stderrOutput, $exitCode);
         if (0 !== $exitCode) {
             throw new Exception('Unable to generate baseline:'. $stderrOutput);
         }


### PR DESCRIPTION
Sieht so aus wenn alle Werte auf 0 stehen (das nackige project-Addon) dann gibt es einen Whoops 

`--allow-empty-baseline` verhindert den Whoops

![image](https://user-images.githubusercontent.com/330560/209484823-c3dd1c63-372b-4935-be6c-86dbe64fe632.png)

**ERROR No errors found ...** ist ja auch irgendwie krass :)