### PR TITLE
WebUI wirft Fehler, weil Pfad nicht stimmt

### DIFF
--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -7,7 +7,7 @@ use staabm\PHPStanDba\QueryReflection\RuntimeConfiguration;
 unset($REX);
 $REX['REDAXO'] = false;
 
-if (is_dir(__DIR__.'/../../../vendor/')) {
+if (is_dir(__DIR__.'/../../../var/')) {
     // yakamara directoy layout
     $REX['HTDOCS_PATH'] = realpath(__DIR__.'/../../../');
     require __DIR__ . '/../../../src/path_provider.php';


### PR DESCRIPTION
![Zwischenablage-1](https://user-images.githubusercontent.com/1277494/211327198-1eb01370-0ad7-44fa-8175-ae81d7485b2a.jpg)

Ich weiß nicht, ob das intern geändert wurde, (@gharlan ?) aber ich verwende das "Yakamara directory layout" von hier:
https://github.com/yakamara/yak
Dort ist kein "vendor" Verzeichnis vorgegeben, weshalb 
https://github.com/FriendsOfREDAXO/rexstan/blob/main/phpstan-bootstrap.php#L10
bei mir dann ins "else" verzweigt und die falschen Pfade setzt und so den Fehler produziert.

Daher denke ich es bietet sich dann eher "var" als Selektions-Kriterium an, was ich im PR geändert habe.