### PR TITLE
use fixed dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,20 @@
 {
     "require": {
         "php": ">=7.4",
-        "phpstan/phpstan": "^1.9.12",
-        "phpstan/phpstan-symfony": "^1.2",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-strict-rules": "^1.4",
-        "phpstan/phpstan-phpunit": "^1.3",
-        "staabm/phpstan-dba": "^0.2.56",
-        "spaze/phpstan-disallowed-calls": "^2.11",
-        "symplify/phpstan-rules": "^11.1",
-        "staabm/phpstan-baseline-analysis": "^0.9",
-        "tomasvotruba/unused-public": "0.0.34.*",
-        "tomasvotruba/type-coverage": "0.0.9.*",
-        "tomasvotruba/cognitive-complexity": "0.0.5.*",
-        "thecodingmachine/safe": "^1.3",
-        "thecodingmachine/phpstan-safe-rule": "^1.2"
+        "phpstan/phpstan": "1.9.12",
+        "phpstan/phpstan-symfony": "1.2.20",
+        "phpstan/phpstan-deprecation-rules": "1.1.1",
+        "phpstan/phpstan-strict-rules": "1.4.5",
+        "phpstan/phpstan-phpunit": "1.3.3",
+        "staabm/phpstan-dba": "0.2.56",
+        "spaze/phpstan-disallowed-calls": "2.11.4",
+        "symplify/phpstan-rules": "11.1.28.72",
+        "staabm/phpstan-baseline-analysis": "0.9.3",
+        "tomasvotruba/unused-public": "0.0.34.72",
+        "tomasvotruba/type-coverage": "0.0.9.72",
+        "tomasvotruba/cognitive-complexity": "0.0.5.72",
+        "thecodingmachine/safe": "1.3.3",
+        "thecodingmachine/phpstan-safe-rule": "1.2"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
rexstan is a application, not a library which gets installed in tandem with other dependencies. therefore use fixed versions