### PR TITLE
Parse-Error in RexSqlInjectionRule.php

### DIFF
--- a/lib/rule/RexSqlInjectionRule.php
+++ b/lib/rule/RexSqlInjectionRule.php
@@ -57,7 +57,7 @@ final class RexSqlInjectionRule implements Rule
     ];
 
     public function __construct(
-        ExprPrinter $exprPrinter,
+        ExprPrinter $exprPrinter
     ) {
         $this->exprPrinter = $exprPrinter;
     }


### PR DESCRIPTION
PHPSTAN: Fehler
PHP Parse error: syntax error, unexpected ')', expecting variable (T_VARIABLE) in ...\redaxo\src\addons\rexstan\lib\rule\RexSqlInjectionRule.php on line 61
Parse error: syntax error, unexpected ')', expecting variable (T_VARIABLE) in ...\redaxo\src\addons\rexstan\lib\rule\RexSqlInjectionRule.php on line 61