### PR TITLE
try to fix installer ignore

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -27,4 +27,4 @@ requires:
 
 installer_ignore:
     - phpstan.dev.neon
-    - tests/
+    - tests


### PR DESCRIPTION
before this PR the "tests/" folder was still contained in the releases.
lets see whether this change fixes it.

refs https://github.com/FriendsOfREDAXO/rexstan/issues/401