### PR TITLE
Relative Pfade nutzen

### DIFF
--- a/install.php
+++ b/install.php
@@ -1,6 +1,7 @@
 <?php
 
 use rexstan\RexCmd;
+use rexstan\RexStanSettings;
 use rexstan\RexStanUserConfig;
 
 $addon = rex_addon::get('rexstan');
@@ -33,27 +34,27 @@ if (!is_file($userConfigPath)) {
     $paths = [];
 
     $projectAddon = rex_addon::get('project');
-    $paths[] = $projectAddon->getPath();
+    $paths[] = RexStanSettings::relativePath($projectAddon->getPath());
 
     RexStanUserConfig::save(0, $paths, [], 70300);
 }
 if (rex_version::compare(rex::getVersion(), '5.15.0-dev', '>=')) {
     $configFileContent = '# rexstan auto generated file - do not edit, delete, rename'. PHP_EOL . PHP_EOL .
         'includes:'. PHP_EOL .
-        '    - ' . $addon->getPath('default-config.neon') . PHP_EOL .
-        '    - ' . $addon->getPath('config/_from-r5_15.neon') . PHP_EOL .
-        '    - ' . $userConfigPath. PHP_EOL;
+        '    - default-config.neon' . PHP_EOL .
+        '    - config/_from-r5_15.neon' . PHP_EOL .
+        '    - ' . RexStanSettings::relativePath($userConfigPath, $addon->getPath()). PHP_EOL;
 } else {
     $configFileContent = '# rexstan auto generated file - do not edit, delete, rename'. PHP_EOL . PHP_EOL .
         'includes:'. PHP_EOL .
-        '    - ' . $addon->getPath('default-config.neon') . PHP_EOL .
-        '    - ' . $addon->getPath('config/_up-to-r5_14.neon') . PHP_EOL .
-        '    - ' . $userConfigPath. PHP_EOL;
+        '    - default-config.neon' . PHP_EOL .
+        '    - config/_up-to-r5_14.neon' . PHP_EOL .
+        '    - ' . RexStanSettings::relativePath($userConfigPath, $addon->getPath()). PHP_EOL;
 }
 
 rex_dir::create($addon->getCachePath());
 $configFileContent .= PHP_EOL .'parameters:'. PHP_EOL .
-'    tmpDir: '.$addon->getCachePath() . PHP_EOL;
+'    tmpDir: '.RexStanSettings::relativePath($addon->getCachePath(), $addon->getPath()) . PHP_EOL;
 
 $configPath = __DIR__.'/phpstan.neon';
 if (false === rex_file::put($configPath, $configFileContent)) {

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -115,7 +115,7 @@ final class RexStanSettings
             $baselineButton .= '<a href="'. $url .'">Baseline im Editor &ouml;ffnen</a> - ';
         }
 
-        self::fixPaths();
+        self::fixAbsoluteToRelativePaths();
 
         $form = rex_config_form::factory('rexstan');
         $field = $form->addInputField('number', 'level', null, ['class' => 'form-control', 'min' => 0, 'max' => 9]);
@@ -243,7 +243,10 @@ final class RexStanSettings
         return implode(', ', $extensions);
     }
 
-    private static function fixPaths(): void
+    /**
+     * Migrate settings which were stored with absolute paths in the past to relative ones.
+     */
+    private static function fixAbsoluteToRelativePaths(): void
     {
         $absolutePath = rex_path::base();
 

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -65,7 +65,7 @@ final class RexStanSettings
     {
         $extensions = [];
         foreach (self::$phpstanExtensions as $label => $path) {
-            $extensions[rex_path::addon('rexstan', $path)] = $label;
+            $extensions[self::relativePath(rex_path::addon('rexstan', $path))] = $label;
         }
 
         $extensionLinks = [];
@@ -75,17 +75,17 @@ final class RexStanSettings
 
         $scanTargets = [];
         foreach (rex_addon::getAvailableAddons() as $availableAddon) {
-            $scanTargets[$availableAddon->getPath()] = $availableAddon->getName();
+            $scanTargets[self::relativePath($availableAddon->getPath())] = $availableAddon->getName();
 
             if ('developer' === $availableAddon->getName()) {
                 $modulesDir = DeveloperAddonIntegration::getModulesDir();
                 if ($modulesDir !== null) {
-                    $scanTargets[$modulesDir] = 'developer: modules';
+                    $scanTargets[self::relativePath($modulesDir)] = 'developer: modules';
                 }
 
                 $templatesDir = DeveloperAddonIntegration::getTemplatesDir();
                 if ($templatesDir !== null) {
-                    $scanTargets[$templatesDir] = 'developer: templates';
+                    $scanTargets[self::relativePath($templatesDir)] = 'developer: templates';
                 }
             }
         }
@@ -195,6 +195,14 @@ final class RexStanSettings
         $output .= '</table>';
 
         return $output;
+    }
+
+    public static function relativePath(string $path, ?string $base = null): string
+    {
+        $relativeAddonPath = rex_path::relative($base ?? rex_path::addonData('rexstan'));
+        $prefix = str_repeat('..' . DIRECTORY_SEPARATOR, substr_count($relativeAddonPath, DIRECTORY_SEPARATOR));
+
+        return $prefix . rex_path::relative($path);
     }
 
     private static function getAddOns(): string

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -253,7 +253,7 @@ final class RexStanSettings
         foreach (['addons', 'extensions'] as $key) {
             $config = rex_config::get('rexstan', $key);
 
-            if (!str_contains($config, $absolutePath)) {
+            if (stripos($config, $absolutePath) === false) {
                 continue;
             }
 

--- a/lib/RexStanSettings.php
+++ b/lib/RexStanSettings.php
@@ -115,6 +115,8 @@ final class RexStanSettings
             $baselineButton .= '<a href="'. $url .'">Baseline im Editor &ouml;ffnen</a> - ';
         }
 
+        self::fixPaths();
+
         $form = rex_config_form::factory('rexstan');
         $field = $form->addInputField('number', 'level', null, ['class' => 'form-control', 'min' => 0, 'max' => 9]);
         $field->setLabel('Level');
@@ -241,4 +243,23 @@ final class RexStanSettings
         return implode(', ', $extensions);
     }
 
+    private static function fixPaths(): void
+    {
+        $absolutePath = rex_path::base();
+
+        foreach (['addons', 'extensions'] as $key) {
+            $config = rex_config::get('rexstan', $key);
+
+            if (!str_contains($config, $absolutePath)) {
+                continue;
+            }
+
+            $config = explode('|', trim($config, '|'));
+            foreach ($config as $i => $path) {
+                $config[$i] = self::relativePath($path);
+            }
+
+            rex_config::set('rexstan', $key, '|'.implode('|', $config).'|');
+        }
+    }
 }

--- a/lib/RexStanUserConfig.php
+++ b/lib/RexStanUserConfig.php
@@ -28,12 +28,12 @@ final class RexStanUserConfig
         foreach (rex_package::getAvailablePackages() as $package) {
             $functionsPath = $package->getPath('functions/');
             if (is_dir($functionsPath)) {
-                $scanDirectories[] = $functionsPath;
+                $scanDirectories[] = RexStanSettings::relativePath($functionsPath);
             }
 
             $vendorsPath = $package->getPath('vendor/');
             if (is_dir($vendorsPath)) {
-                $scanDirectories[] = $vendorsPath;
+                $scanDirectories[] = RexStanSettings::relativePath($vendorsPath);
             }
         }
 

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -33,7 +33,7 @@ if (rex_post($form_name . '_save', 'bool', false)) {
     }
 
     if ($analysisBaseline !== null) {
-        $includes[] = RexStanSettings::getAnalysisBaselinePath();
+        $includes[] = basename(RexStanSettings::getAnalysisBaselinePath());
     }
 
     RexStanUserConfig::save($level, $paths, $includes, $phpversion);


### PR DESCRIPTION
Damit die Config-Dateien commitet werden können.

Relative Pfade innerhalb von phpstan-Config-Dateien müssen jeweils relativ zu dem Speicherort der Datei sein:
https://phpstan.org/config-reference#multiple-files
> Relative paths in the includes section are resolved based on the directory of the config file is in.

Refs https://github.com/FriendsOfREDAXO/rexstan/issues/200#issuecomment-1472657290