### PR TITLE
fix: use double quotes

### DIFF
--- a/lib/RexPhpVersion.php
+++ b/lib/RexPhpVersion.php
@@ -11,7 +11,7 @@ final class RexPhpVersion {
     }
 
     static public function getCliVersion(): int {
-        $output = RexCmd::execCmd('php -r \'echo PHP_VERSION_ID;\'', $stderrOutput, $exitCode);
+        $output = RexCmd::execCmd('php -r "echo PHP_VERSION_ID;"', $stderrOutput, $exitCode);
 
         if ($exitCode !== 0) {
             throw new \RuntimeException('Could not get PHP version from CLI: ' . $stderrOutput);


### PR DESCRIPTION
Werden die Quotes nur escaped bekomme ich auf Windows ein Problem. Ich kann natürlich nicht sagen ob das nun auf einem Mac Probleme bereitet.
![grafik](https://user-images.githubusercontent.com/2708231/225869605-511127ca-3cb4-4d43-ad00-e457e773331c.png)
