### PR TITLE
fix deprecation in RexGetValueRule

### DIFF
--- a/lib/rule/RexGetValueRule.php
+++ b/lib/rule/RexGetValueRule.php
@@ -82,7 +82,11 @@ final class RexGetValueRule implements Rule
 
             $errors[] =
                 RuleErrorBuilder::message(
-                    sprintf('Unknown name %s given to getValue().', $nameType->describe(VerbosityLevel::precise()))
+                    sprintf(
+                        'Unknown name %s given to %s::getValue().',
+                        $nameType->describe(VerbosityLevel::precise()),
+                        $className
+                    )
                 )->build()
             ;
         }

--- a/lib/rule/RexGetValueRule.php
+++ b/lib/rule/RexGetValueRule.php
@@ -61,30 +61,32 @@ final class RexGetValueRule implements Rule
             return [];
         }
 
+        $errors = [];
         $callerType = $scope->getType($methodCall->var);
-        if (!$callerType instanceof TypeWithClassName) {
-            return [];
+        $classNames = $callerType->getObjectClassNames();
+        foreach($classNames as $className) {
+            if (!in_array($className, $this->classes, true)) {
+                continue;
+            }
+
+            $nameType = $scope->getType($args[0]->value);
+            $names = $nameType->getConstantStrings();
+            if (0 === count($names)) {
+                return [];
+            }
+
+            $valueReflection = new RexGetValueReflection();
+            if (null !== $valueReflection->getValueType($nameType, $className)) {
+                return [];
+            }
+
+            $errors[] =
+                RuleErrorBuilder::message(
+                    sprintf('Unknown name %s given to getValue().', $nameType->describe(VerbosityLevel::precise()))
+                )->build()
+            ;
         }
 
-        if (!in_array($callerType->getClassName(), $this->classes, true)) {
-            return [];
-        }
-
-        $nameType = $scope->getType($args[0]->value);
-        $names = $nameType->getConstantStrings();
-        if (0 === count($names)) {
-            return [];
-        }
-
-        $valueReflection = new RexGetValueReflection();
-        if (null !== $valueReflection->getValueType($nameType, $callerType->getClassName())) {
-            return [];
-        }
-
-        return [
-            RuleErrorBuilder::message(
-                sprintf('Unknown name %s given to getValue().', $nameType->describe(VerbosityLevel::precise()))
-            )->build(),
-        ];
+        return $errors;
     }
 }

--- a/tests/expected.out
+++ b/tests/expected.out
@@ -15,12 +15,12 @@
 /tests/data/any-get.php:13:No rex_media found with id 'does-not-exist.jpg'.
 /tests/data/any-get.php:14:No rex_article found with id 9999999.
 /tests/data/any-get.php:15:No rex_category found with id 9999999.
-/tests/data/object-oriented-framework.php:22:Unknown name 'unknownColumn' given to getValue().
+/tests/data/object-oriented-framework.php:22:Unknown name 'unknownColumn' given to rex_user::getValue().
 /tests/data/object-oriented-framework.php:24:No rex_media found with id 'markus.jpg'.
-/tests/data/object-oriented-framework.php:30:Unknown name 'unknownColumn' given to getValue().
-/tests/data/object-oriented-framework.php:38:Unknown name 'unknownColumn' given to getValue().
-/tests/data/object-oriented-framework.php:46:Unknown name 'unknownColumn' given to getValue().
-/tests/data/object-oriented-framework.php:51:Unknown name 'unknownColumn' given to getValue().
+/tests/data/object-oriented-framework.php:30:Unknown name 'unknownColumn' given to rex_media::getValue().
+/tests/data/object-oriented-framework.php:38:Unknown name 'unknownColumn' given to rex_article::getValue().
+/tests/data/object-oriented-framework.php:46:Unknown name 'unknownColumn' given to rex_category::getValue().
+/tests/data/object-oriented-framework.php:51:Unknown name 'unknownColumn' given to rex_article_slice::getValue().
 /tests/data/object-oriented-framework.php:58:No rex_media found with id 'markus.jpg'.
 /tests/data/sql-get-value.php:45:Value 'doesNotExist' was not selected in the used sql-query.
 /tests/data/sql-get-value.php:46:Value 'doesNotExist' was not selected in the used sql-query.


### PR DESCRIPTION
> Doing instanceof PHPStan\Type\TypeWithClassName is error-prone and deprecated. Use Type::getObjectClassNames() or Type::getObjectClassReflections() instead.