### PR TITLE
implement YOrmDatasetGetValueDynamicReturnTypeExtension

### DIFF
--- a/config/phpstan-dba.neon
+++ b/config/phpstan-dba.neon
@@ -134,3 +134,4 @@ services:
         class: rexstan\YOrmDatasetGetValueDynamicReturnTypeExtension
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
+

--- a/config/phpstan-dba.neon
+++ b/config/phpstan-dba.neon
@@ -130,3 +130,7 @@ services:
         tags:
             - phpstan.broker.dynamicMethodReturnTypeExtension
 
+    -
+        class: rexstan\YOrmDatasetGetValueDynamicReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension

--- a/lib/extension/RexSqlGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/RexSqlGetValueDynamicReturnTypeExtension.php
@@ -22,7 +22,7 @@ final class RexSqlGetValueDynamicReturnTypeExtension implements DynamicMethodRet
 
     public function isMethodSupported(MethodReflection $methodReflection): bool
     {
-        return in_array(strtolower($methodReflection->getName()), ['getvalue'], true);
+        return strtolower($methodReflection->getName()) === 'getvalue';
     }
 
     public function getTypeFromMethodCall(

--- a/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
@@ -56,7 +56,6 @@ final class YOrmDatasetGetValueDynamicReturnTypeExtension implements DynamicMeth
         $datasetObject = $scope->getType($methodCall->var);
         $classReflections = $datasetObject->getObjectClassReflections();
 
-        /** @var ObjectType $results */
         $results = [];
         foreach($classReflections as $classReflection) {
             if (!$classReflection->isSubclassOf(rex_yform_manager_dataset::class)) {

--- a/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
@@ -77,6 +77,10 @@ final class YOrmDatasetGetValueDynamicReturnTypeExtension implements DynamicMeth
                     QueryReflector::FETCH_TYPE_ASSOC
                 );
 
+                if ($datasetType === null) {
+                    continue;
+                }
+
                 if (!$datasetType->hasOffsetValueType($constantString)->yes()) {
                     continue;
                 }

--- a/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
@@ -77,10 +77,10 @@ final class YOrmDatasetGetValueDynamicReturnTypeExtension implements DynamicMeth
                     QueryReflector::FETCH_TYPE_ASSOC
                 );
 
-                if (!$datasetType->hasOffsetValueType($constantString->getValue())->yes()) {
+                if (!$datasetType->hasOffsetValueType($constantString)->yes()) {
                     continue;
                 }
-                $results[] = $datasetType->getOffsetValueType($constantString->getValue());
+                $results[] = $datasetType->getOffsetValueType($constantString);
             }
         }
 

--- a/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
@@ -83,6 +83,10 @@ final class YOrmDatasetGetValueDynamicReturnTypeExtension implements DynamicMeth
 
                 $resultType = RexSqlReflection::getResultTypeFromStatementType($statementType);
 
+                if ($resultType === null) {
+                    continue;
+                }
+
                 if (!$resultType->hasOffsetValueType($constantString)->yes()) {
                     continue;
                 }

--- a/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
@@ -70,22 +70,24 @@ final class YOrmDatasetGetValueDynamicReturnTypeExtension implements DynamicMeth
             }
 
             foreach($constantStrings as $constantString) {
-                $datasetType = RexSqlReflection::inferStatementType(
+                $statementType = RexSqlReflection::inferStatementType(
                     new String_('SELECT * FROM '. $datasetObject->getTableName()),
                     null,
                     $scope,
                     QueryReflector::FETCH_TYPE_ASSOC
                 );
 
-                if ($datasetType === null) {
+                if ($statementType === null) {
                     continue;
                 }
 
-                if (!$datasetType->hasOffsetValueType($constantString)->yes()) {
+                $resultType = RexSqlReflection::getResultTypeFromStatementType($statementType);
+
+                if (!$resultType->hasOffsetValueType($constantString)->yes()) {
                     continue;
                 }
-                
-                $results[] = $datasetType->getOffsetValueType($constantString);
+
+                $results[] = $resultType->getOffsetValueType($constantString);
             }
         }
 

--- a/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
@@ -16,6 +16,7 @@ use PHPStan\Type\TypeCombinator;
 use rex_yform_manager_collection;
 use rex_yform_manager_dataset;
 use rex_yform_manager_query;
+use staabm\PHPStanDba\QueryReflection\QueryReflector;
 use function count;
 use function in_array;
 
@@ -69,7 +70,12 @@ final class YOrmDatasetGetValueDynamicReturnTypeExtension implements DynamicMeth
             }
 
             foreach($constantStrings as $constantString) {
-                $datasetType = RexSqlReflection::inferStatementType(new String_('SELECT * FROM '. $datasetObject->getTableName()), $scope);
+                $datasetType = RexSqlReflection::inferStatementType(
+                    new String_('SELECT * FROM '. $datasetObject->getTableName()),
+                    null,
+                    $scope,
+                    QueryReflector::FETCH_TYPE_ASSOC
+                );
 
                 if (!$datasetType->hasOffsetValueType($constantString->getValue())->yes()) {
                     continue;

--- a/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rexstan;
+
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use rex_yform_manager_collection;
+use rex_yform_manager_dataset;
+use rex_yform_manager_query;
+use function count;
+use function in_array;
+
+final class YOrmDatasetGetValueDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        // @phpstan-ignore-next-line
+        return rex_yform_manager_dataset::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return strtolower($methodReflection->getName())  === 'getvalue';
+    }
+
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope
+    ): ?Type {
+        $args = $methodCall->getArgs();
+        if (1 < count($args)) {
+            return null;
+        }
+
+        if (!class_exists(rex_yform_manager_dataset::class)) {
+            return null;
+        }
+
+        $key = $scope->getType($args[0]->value);
+        $constantStrings = $key->getConstantStrings();
+        if ($constantStrings === []) {
+            return null;
+        }
+
+        $datasetObject = $scope->getType($methodCall->var);
+        $classReflections = $datasetObject->getObjectClassReflections();
+
+        /** @var ObjectType $results */
+        $results = [];
+        foreach($classReflections as $classReflection) {
+            if (!$classReflection->isSubclassOf(rex_yform_manager_dataset::class)) {
+                continue;
+            }
+
+            // @phpstan-ignore-next-line
+            $datasetObject = call_user_func([$classReflection->getName(), 'create']);
+            if (!$datasetObject instanceof rex_yform_manager_dataset) {
+                throw new \RuntimeException('expecting dataset object');
+            }
+
+            foreach($constantStrings as $constantString) {
+                $datasetType = RexSqlReflection::inferStatementType(new String_('SELECT * FROM '. $datasetObject->getTableName()), $scope);
+
+                if (!$datasetType->hasOffsetValueType($constantString->getValue())->yes()) {
+                    continue;
+                }
+                $results[] = $datasetType->getOffsetValueType($constantString->getValue());
+            }
+        }
+
+        if ($results === []) {
+            return null;
+        }
+
+        return TypeCombinator::union(...$results);
+
+    }
+}

--- a/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
+++ b/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php
@@ -84,6 +84,7 @@ final class YOrmDatasetGetValueDynamicReturnTypeExtension implements DynamicMeth
                 if (!$datasetType->hasOffsetValueType($constantString)->yes()) {
                     continue;
                 }
+                
                 $results[] = $datasetType->getOffsetValueType($constantString);
             }
         }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -2076,6 +2076,7 @@ return array(
     'rexstan\\RexTemplateVarsReflection' => $baseDir . '/lib/reflection/RexTemplateVarsReflection.php',
     'rexstan\\RexTemplateVarsRule' => $baseDir . '/lib/rule/RexTemplateVarsRule.php',
     'rexstan\\RexUserGetValueDynamicReturnTypeExtension' => $baseDir . '/lib/extension/RexUserGetValueDynamicReturnTypeExtension.php',
+    'rexstan\\YOrmDatasetGetValueDynamicReturnTypeExtension' => $baseDir . '/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php',
     'rexstan\\YOrmDatasetOptionalTableRule' => $baseDir . '/lib/rule/YOrmDatasetOptionalTableRule.php',
     'rexstan\\YOrmDatasetRelatedDataDynamicReturnTypeExtension' => $baseDir . '/lib/extension/YOrmDatasetRelatedDataDynamicReturnTypeExtension.php',
     'rexstan\\rexstan_command' => $baseDir . '/lib/command.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -2271,6 +2271,7 @@ class ComposerStaticInit9cf8af24a7a084f114b4553be2a1ff9f
         'rexstan\\RexTemplateVarsReflection' => __DIR__ . '/../..' . '/lib/reflection/RexTemplateVarsReflection.php',
         'rexstan\\RexTemplateVarsRule' => __DIR__ . '/../..' . '/lib/rule/RexTemplateVarsRule.php',
         'rexstan\\RexUserGetValueDynamicReturnTypeExtension' => __DIR__ . '/../..' . '/lib/extension/RexUserGetValueDynamicReturnTypeExtension.php',
+        'rexstan\\YOrmDatasetGetValueDynamicReturnTypeExtension' => __DIR__ . '/../..' . '/lib/extension/YOrmDatasetGetValueDynamicReturnTypeExtension.php',
         'rexstan\\YOrmDatasetOptionalTableRule' => __DIR__ . '/../..' . '/lib/rule/YOrmDatasetOptionalTableRule.php',
         'rexstan\\YOrmDatasetRelatedDataDynamicReturnTypeExtension' => __DIR__ . '/../..' . '/lib/extension/YOrmDatasetRelatedDataDynamicReturnTypeExtension.php',
         'rexstan\\rexstan_command' => __DIR__ . '/../..' . '/lib/command.php',


### PR DESCRIPTION
einfache form um `getValue()` zu ermöglichen, wenn konstante strings übergeben werden die 1:1 eine db spalte entsprechen

refs https://github.com/FriendsOfREDAXO/rexstan/issues/410