### PR TITLE
Manually patch parallel-lint to make it faster

### DIFF
--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -726,6 +726,7 @@ return array(
     'PHPStan\\Type\\Symfony\\SerializerDynamicReturnTypeExtension' => $vendorDir . '/phpstan/phpstan-symfony/src/Type/Symfony/SerializerDynamicReturnTypeExtension.php',
     'PHPStan\\Type\\Symfony\\ServiceDynamicReturnTypeExtension' => $vendorDir . '/phpstan/phpstan-symfony/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php',
     'PHPStan\\Type\\Symfony\\ServiceTypeSpecifyingExtension' => $vendorDir . '/phpstan/phpstan-symfony/src/Type/Symfony/ServiceTypeSpecifyingExtension.php',
+    'PHP_Parallel_Lint\\PhpParallelLint\\FilteredRecursiveDirectoryIterator' => $vendorDir . '/php-parallel-lint/php-parallel-lint/src/FilteredRecursiveDirectoryIterator.php',
     'PhpParser\\Builder' => $vendorDir . '/nikic/php-parser/lib/PhpParser/Builder.php',
     'PhpParser\\BuilderFactory' => $vendorDir . '/nikic/php-parser/lib/PhpParser/BuilderFactory.php',
     'PhpParser\\BuilderHelpers' => $vendorDir . '/nikic/php-parser/lib/PhpParser/BuilderHelpers.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -929,6 +929,7 @@ class ComposerStaticInit9cf8af24a7a084f114b4553be2a1ff9f
         'PHPStan\\Type\\Symfony\\SerializerDynamicReturnTypeExtension' => __DIR__ . '/..' . '/phpstan/phpstan-symfony/src/Type/Symfony/SerializerDynamicReturnTypeExtension.php',
         'PHPStan\\Type\\Symfony\\ServiceDynamicReturnTypeExtension' => __DIR__ . '/..' . '/phpstan/phpstan-symfony/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php',
         'PHPStan\\Type\\Symfony\\ServiceTypeSpecifyingExtension' => __DIR__ . '/..' . '/phpstan/phpstan-symfony/src/Type/Symfony/ServiceTypeSpecifyingExtension.php',
+        'PHP_Parallel_Lint\\PhpParallelLint\\FilteredRecursiveDirectoryIterator' => __DIR__ . '/..' . '/php-parallel-lint/php-parallel-lint/src/FilteredRecursiveDirectoryIterator.php',
         'PhpParser\\Builder' => __DIR__ . '/..' . '/nikic/php-parser/lib/PhpParser/Builder.php',
         'PhpParser\\BuilderFactory' => __DIR__ . '/..' . '/nikic/php-parser/lib/PhpParser/BuilderFactory.php',
         'PhpParser\\BuilderHelpers' => __DIR__ . '/..' . '/nikic/php-parser/lib/PhpParser/BuilderHelpers.php',

--- a/vendor/php-parallel-lint/php-parallel-lint/src/FilteredRecursiveDirectoryIterator.php
+++ b/vendor/php-parallel-lint/php-parallel-lint/src/FilteredRecursiveDirectoryIterator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PHP_Parallel_Lint\PhpParallelLint;
+
+use ReturnTypeWillChange;
+
+class FilteredRecursiveDirectoryIterator extends \RecursiveDirectoryIterator
+{
+    private $excluded = array();
+
+    public function __construct($path, $flags = null, array $excluded = array())
+    {
+        $this->excluded = $excluded;
+
+        if ($flags === null) {
+            $flags = \FilesystemIterator::KEY_AS_PATHNAME | \FilesystemIterator::CURRENT_AS_FILEINFO;
+        }
+
+        parent::__construct($path, $flags);
+    }
+
+    #[ReturnTypeWillChange]
+    public function hasChildren($allowLinks = false)
+    {
+        if (in_array($this->getBasename(), $this->excluded)) {
+            return false;
+        }
+
+        return parent::hasChildren($allowLinks);
+    }
+}

--- a/vendor/php-parallel-lint/php-parallel-lint/src/Manager.php
+++ b/vendor/php-parallel-lint/php-parallel-lint/src/Manager.php
@@ -4,6 +4,7 @@ namespace JakubOnderka\PhpParallelLint;
 use JakubOnderka\PhpParallelLint\Contracts\SyntaxErrorCallback;
 use JakubOnderka\PhpParallelLint\Process\GitBlameProcess;
 use JakubOnderka\PhpParallelLint\Process\PhpExecutable;
+use PHP_Parallel_Lint\PhpParallelLint\FilteredRecursiveDirectoryIterator;
 use ReturnTypeWillChange;
 
 class Manager
@@ -149,7 +150,7 @@ class Manager
             } else if (is_dir($path)) {
                 $iterator = new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS);
                 if (!empty($excluded)) {
-                    $iterator = new RecursiveDirectoryFilterIterator($iterator, $excluded);
+                    $iterator = new FilteredRecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS, $excluded);
                 }
                 $iterator = new \RecursiveIteratorIterator(
                     $iterator,


### PR DESCRIPTION
patch from https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/136

running
```
 blackfire run php /Users/staabm/workspace/redaxo/redaxo/src/addons/rexstan/vendor/bin/parallel-lint /Users/staabm/workspace/redaxo/redaxo/src/addons/rexstan --json --no-progress --no-colors --exclude .git --exclude .svn --exclude .idea --exclude vendor --exclude node_modules
```

before
<img width="638" alt="grafik" src="https://user-images.githubusercontent.com/120441/230760721-1bbdfeb5-1367-4c30-b30c-50b18e60d4fa.png">

after
<img width="660" alt="grafik" src="https://user-images.githubusercontent.com/120441/230760732-4bef5a8a-14b8-4975-8074-cdd84df375fc.png">
