### PR TITLE
don't print analysed linting paths

### DIFF
--- a/pages/lint-analysis.php
+++ b/pages/lint-analysis.php
@@ -13,8 +13,6 @@ if (count($errors) > 0) {
     }
 } else {
     echo rex_view::success('Gratulation, es wurden keine Linting Fehler gefunden.');
-
-    echo '<p>Untersuchte Pfade<ul><li>'. implode('</li><li>', RexLint::getPathsToLint()) .'</li></ul></p>';
 }
 
 $cliVersion = RexCmd::getFormattedCliPhpVersion();


### PR DESCRIPTION
since we lint only addons [which are configured in the settings tab](https://github.com/FriendsOfREDAXO/rexstan/pull/474), we no longer need to output the linted paths