### PR TITLE
Sponsoring-Link und Zeit auf den anderen AddOn-Seiten am Ende ausgeben

### DIFF
--- a/pages/index.php
+++ b/pages/index.php
@@ -22,3 +22,13 @@ echo '
 echo rex_view::title('<span class="rexstan-logo"><img src="'.$logoPath.'" width="200" height="90" ></span>');
 
 rex_be_controller::includeCurrentPageSubPath();
+
+if ('settings' !== rex_be_controller::getCurrentPagePart(2)) {
+    $url = '<small><a href="https://github.com/sponsors/staabm">Support <strong>rexstan</strong> with your sponsoring 💕</a></small>';
+    $scripttime = rex::getProperty('timer')->getFormattedDelta(rex_timer::SEC);
+
+    echo '<div style="text-align:center;"><p>';
+    echo $url . ' - <small>' . rex_i18n::msg('footer_scripttime', $scripttime) . '</small>';
+    echo ' <small><a href="#top"><i class="rex-icon fa fa-arrow-up"></i></a></small>';
+    echo '</p></div>';
+}


### PR DESCRIPTION
@staabm 

Das ist nur ein Vorschlag :)

Am Ende der anderen Seiten ausser Settings zusätzlich den Sponsoring-Link ausgeben.

Wie auf allen anderen Backend-Seiten auch die Script-Laufzeit ausgeben.