### PR TITLE
Dependabot: disable grouping again

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,3 @@ updates:
             interval: daily
         open-pull-requests-limit: 15
         vendor: true
-
-        groups:
-          production-dependencies:
-            dependency-type: "production"
-          development-dependencies:
-            dependency-type: "development"


### PR DESCRIPTION
having separate PRs leads to a better changelog