### PR TITLE
remove unsupported depedanbot vendoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
         schedule:
             interval: daily
         open-pull-requests-limit: 15
-        vendor: true


### PR DESCRIPTION
should fix

> The property '#/updates/0/' contains additional properties ["vendor"] outside of the schema when none are allowed