### PR TITLE
DX: print stderr output

### DIFF
--- a/lib/RexStan.php
+++ b/lib/RexStan.php
@@ -34,6 +34,8 @@ final class RexStan
             $cmd .= ' --level '. $level;
         }
 
+        $cmd .= ' 2>&1';
+
         return RexCmd::execCmd($cmd, $errorOutput, $exitCode);
     }
 

--- a/lib/command.php
+++ b/lib/command.php
@@ -26,6 +26,7 @@ class rexstan_command extends rex_console_command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = $this->getStyle($input, $output);
+        $stdErr = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
 
         $path = null;
         $level = null;
@@ -49,6 +50,10 @@ class rexstan_command extends rex_console_command
 
         if ($result !== '') {
             $io->write($result);
+        }
+
+        if ($errorOutput !== '') {
+            $stdErr->write($errorOutput);
         }
 
         // pass PHPStan exit code 1:1

--- a/lib/command.php
+++ b/lib/command.php
@@ -6,6 +6,7 @@ use rex_console_command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class rexstan_command extends rex_console_command


### PR DESCRIPTION
to ease debugging, like in https://github.com/redaxo/redaxo.org/issues/104 where rexstan fails without any output