### PR TITLE
RexFunctionsDynamicReturnTypeExtension - fix default arg handling

### DIFF
--- a/lib/extension/RexFunctionsDynamicReturnTypeExtension.php
+++ b/lib/extension/RexFunctionsDynamicReturnTypeExtension.php
@@ -78,7 +78,8 @@ final class RexFunctionsDynamicReturnTypeExtension implements DynamicFunctionRet
         $results = [];
         if (count($args) >= 3) {
             $defaultArgType = $scope->getType($args[2]->value);
-            if (!$defaultArgType instanceof ConstantStringType || $defaultArgType->getValue() !== '') {
+            $defaultArgTypeStrings = $defaultArgType->getConstantStrings();
+            if (count($defaultArgTypeStrings) !== 1 || $defaultArgTypeStrings[0]->getValue() !== '') {
                 $results[] = $defaultArgType;
             }
         }

--- a/lib/extension/RexFunctionsDynamicReturnTypeExtension.php
+++ b/lib/extension/RexFunctionsDynamicReturnTypeExtension.php
@@ -7,6 +7,7 @@ namespace rexstan;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Reflection\MethodReflection;
@@ -74,14 +75,16 @@ final class RexFunctionsDynamicReturnTypeExtension implements DynamicFunctionRet
             return null;
         }
 
-        $defaultArgType = new ConstantStringType('');
+        $results = [];
         if (count($args) >= 3) {
             $defaultArgType = $scope->getType($args[2]->value);
+            if (!$defaultArgType instanceof ConstantStringType || $defaultArgType->getValue() !== '') {
+                $results[] = $defaultArgType;
+            }
         }
 
         $typeStrings = $scope->getType($args[1]->value)->getConstantStrings();
         if (count($typeStrings) > 0) {
-            $results = [];
             foreach ($typeStrings as $typeString) {
                 $resolvedType = $this->resolveTypeFromString($typeString->getValue());
                 if ($resolvedType === null) {
@@ -91,7 +94,7 @@ final class RexFunctionsDynamicReturnTypeExtension implements DynamicFunctionRet
                 $results[] = $resolvedType;
             }
 
-            return TypeCombinator::union($defaultArgType, ...$results);
+            return TypeCombinator::union(...$results);
         }
 
         return null;

--- a/tests/data/rex-sapi.php
+++ b/tests/data/rex-sapi.php
@@ -44,4 +44,5 @@ function doQux()
     assertType('int', rex_get('HTTP_REFERER', 'int', 1));
     assertType('int|null', rex_get('HTTP_REFERER', 'int', null));
     assertType("'foo'|int", rex_get('HTTP_REFERER', 'int', 'foo'));
+    assertType("'foo'|int", rex_get('HTTP_REFERER', 'int', rand(0,1) ? 'foo' : ''));
 }

--- a/tests/data/rex-sapi.php
+++ b/tests/data/rex-sapi.php
@@ -30,11 +30,18 @@ function doBar()
 function doFooBar()
 {
     assertType('string', rex_get('HTTP_REFERER', 'string', ''));
-    assertType("''|int", rex_get('HTTP_REFERER', 'int', ''));
-    assertType("''|int", rex_get('HTTP_REFERER', 'integer', ''));
-    assertType("''|float", rex_get('HTTP_REFERER', 'float', ''));
-    assertType("''|float", rex_get('HTTP_REFERER', 'double', ''));
-    assertType("''|float", rex_get('HTTP_REFERER', 'real', ''));
-    assertType("''|bool", rex_get('HTTP_REFERER', 'bool', ''));
-    assertType("''|bool", rex_get('HTTP_REFERER', 'boolean', ''));
+    assertType('int', rex_get('HTTP_REFERER', 'int', ''));
+    assertType('int', rex_get('HTTP_REFERER', 'integer', ''));
+    assertType('float', rex_get('HTTP_REFERER', 'float', ''));
+    assertType('float', rex_get('HTTP_REFERER', 'double', ''));
+    assertType('float', rex_get('HTTP_REFERER', 'real', ''));
+    assertType('bool', rex_get('HTTP_REFERER', 'bool', ''));
+    assertType('bool', rex_get('HTTP_REFERER', 'boolean', ''));
+}
+
+function doQux()
+{
+    assertType('int', rex_get('HTTP_REFERER', 'int', 1));
+    assertType('int|null', rex_get('HTTP_REFERER', 'int', null));
+    assertType("'foo'|int", rex_get('HTTP_REFERER', 'int', 'foo'));
 }


### PR DESCRIPTION
Bei den Funktionen `rex_get()`/`rex_post()` etc. wurde mit dem Default-Wert falsch umgegangen.

Wenn man den dritten Param weglässt oder explizit `''` übergibt, ging rexstan bisher davon aus, dass der leere String ein möglicher Rückgabewert ist.
Tatsächlich hat der leere String als Defaultwert aber eine andere Bedeutung. Wenn der Key nicht existiert, dann wird der leere String auf den gewünschten Typ gecastet, also bei int auf 0 etc.

Nur wenn man also einen anderen Wert als Defaultwert übergibt, muss dieser als möglicher Rückgabewert ergänzt werden.