### PR TITLE
Fix "Invalid path" error in rexstan:analyze for any relative path

### DIFF
--- a/lib/command.php
+++ b/lib/command.php
@@ -36,7 +36,7 @@ class rexstan_command extends rex_console_command
 
         $path = null;
         if ($input->getArgument('path') !== null) {
-            $analyzePath = getcwd() .'/../'. $input->getArgument('path');
+            $analyzePath = getcwd() .'/'. $input->getArgument('path');
             $path = realpath($analyzePath);
 
             if ($path === false) {

--- a/lib/command.php
+++ b/lib/command.php
@@ -5,6 +5,7 @@ namespace rexstan;
 use Exception;
 use FriendsOfRedaxo\RexStan\RexStan;
 use rex_console_command;
+use rex_path;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -36,7 +37,7 @@ class rexstan_command extends rex_console_command
 
         $path = null;
         if ($input->getArgument('path') !== null) {
-            $analyzePath = getcwd() .'/'. $input->getArgument('path');
+            $analyzePath = rex_path::base('/'. $input->getArgument('path'));
             $path = realpath($analyzePath);
 
             if ($path === false) {


### PR DESCRIPTION
## Summary
- `rexstan:analyze <path>` throws `Invalid path: <path>` for every valid relative path when run from the project root (the normal way to invoke it), because `lib/command.php` builds the analyze path as `getcwd() . '/../' . $path`.
- `bin/console` does `chdir(dirname(__DIR__))` before booting, so `getcwd()` during command execution is already the project root — not one level below it. The extra `/../` climbs one directory too far, `realpath()` fails, and the command throws.
- Fix: drop the extra `/../`, i.e. `getcwd() . '/' . $path`.

Fixes #1057

## Test plan
- [x] Verified with a temporary debug trace that `getcwd()` equals the project root during command execution (`getcwd()=/var/www/html`, old `analyzePath=/var/www/html/../src/addons/...` → doesn't exist).
- [x] After the fix, `php bin/console rexstan:analyze src/addons/<some-addon>` correctly analyzes the directory and reports findings instead of throwing.
- [x] Verified with a single-file path (`... rexstan:analyze src/addons/<addon>/package.yml`) → `[OK] No errors`.
- Tested on REDAXO 5.21.4, PHP 8.4.24, rexstan 3.0.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)