### PR TITLE
Fix baseline generation hiding its own error behind progress-bar output

### DIFF
--- a/lib/RexStan.php
+++ b/lib/RexStan.php
@@ -82,7 +82,7 @@ final class RexStan
         $addon = rex_addon::get('rexstan');
         $dataDir = $addon->getDataPath();
 
-        RexCmd::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline '. $analysisBaselinePath .' --allow-empty-baseline', $stderrOutput, $exitCode);
+        RexCmd::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline '. $analysisBaselinePath .' --allow-empty-baseline --no-progress', $stderrOutput, $exitCode);
         if ($exitCode !== 0) {
             throw new Exception('Unable to generate analysis baseline:'. $stderrOutput);
         }
@@ -111,7 +111,7 @@ final class RexStan
         $baselineGlob = $dataDir.$configSignature.DIRECTORY_SEPARATOR.'*-summary.json';
         $htmlGraphPath = $dataDir.'baseline-graph.html';
 
-        RexCmd::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline --allow-empty-baseline', $stderrOutput, $exitCode);
+        RexCmd::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline --allow-empty-baseline --no-progress', $stderrOutput, $exitCode);
         if ($exitCode !== 0) {
             throw new Exception('Unable to generate baseline:'. $stderrOutput);
         }


### PR DESCRIPTION
## Summary

`RexStan::generateAnalysisBaseline()` (the "ignore all" button on the analysis page) and `analyzeSummaryBaseline()` (the summary page) invoke PHPStan without `--no-progress`, unlike every other PHPStan invocation in this file.

Depending on environment, PHPStan's progress-bar control characters end up interleaved into the captured stderr output. On failure that raw output lands directly in the thrown exception's message (`"Unable to generate baseline: <progress-bar escape codes>"`), making the actual underlying error unreadable. I hit this myself: a stale Nette container-cache directory was the real cause ("Unable to create file ..."), but it was completely buried under garbled control characters until I added `--no-progress` locally to see through it.

Both call sites now pass `--no-progress`, matching every other PHPStan invocation already in this file.

This is a standalone bugfix, split out from a larger PR per review feedback (one PR per bug) — see #1059. Two follow-up PRs build on top of this one for the actual feature.

## Test plan
- [x] Reproduced the garbled-error symptom, confirmed root cause (stale cache), fixed, then verified `--no-progress` prevents the garbling regardless of the underlying cause.
- [x] `php -l` + PHPStan on the changed file: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)