### PR TITLE
Harden the analysis re-run trigger: no-JS fallback link, timestamp

### DIFF
--- a/assets/rexstan-analysis.js
+++ b/assets/rexstan-analysis.js
@@ -39,6 +39,10 @@
             + '</div>';
     }
 
+    // The trigger link is always server-rendered already (works without JS,
+    // it just reloads the page instead of running this AJAX flow) - this only
+    // (re-)binds the click handler and toggles its visibility/label, it never
+    // builds the link's markup itself.
     function setToolbar(config, running) {
         var toolbar = el('rexstan-analysis-toolbar');
         if (!toolbar) {
@@ -50,14 +54,28 @@
             return;
         }
 
-        var label = config.hasResult ? '🔄 Neu analysieren' : '▶️ Analyse starten';
-        toolbar.innerHTML = '<p><button type="button" id="rexstan-analysis-trigger" class="btn btn-primary">' + label + '</button></p>';
-
         var btn = el('rexstan-analysis-trigger');
-        if (btn) {
-            btn.addEventListener('click', function () {
+        if (!btn) {
+            var label = config.hasResult ? '🔄 Neu analysieren' : '▶️ Analyse starten';
+            toolbar.innerHTML = '<p><a href="#" id="rexstan-analysis-trigger" class="btn btn-primary">' + label + '</a></p>';
+            btn = el('rexstan-analysis-trigger');
+        } else {
+            btn.textContent = config.hasResult ? '🔄 Neu analysieren' : '▶️ Analyse starten';
+        }
+
+        if (btn && btn.dataset.bound !== '1') {
+            btn.dataset.bound = '1';
+            btn.addEventListener('click', function (event) {
+                event.preventDefault();
                 startAnalysis(config);
             });
+        }
+    }
+
+    function setMeta(text) {
+        var meta = el('rexstan-analysis-meta');
+        if (meta) {
+            meta.textContent = text;
         }
     }
 
@@ -89,6 +107,7 @@
                 stopPolling();
                 config.hasResult = true;
                 el('rexstan-analysis-result').innerHTML = data.html || '';
+                setMeta('Ergebnis von gerade eben');
                 setToolbar(config, false);
             })
             .catch(function () {
@@ -99,6 +118,7 @@
 
     function startAnalysis(config) {
         el('rexstan-analysis-result').innerHTML = renderRunningPlaceholder();
+        setMeta('');
         setToolbar(config, true);
 
         fetchJson(config.apiBase + '&action=start')
@@ -138,16 +158,10 @@
         setToolbar(config, !!config.running);
 
         if (config.running) {
+            el('rexstan-analysis-result').innerHTML = renderRunningPlaceholder();
             pollTimer = setInterval(function () {
                 poll(config);
             }, POLL_INTERVAL_MS);
-            return;
-        }
-
-        if (!config.hasResult) {
-            // nothing cached yet on this system - kick off the very first run
-            // automatically instead of showing an empty page
-            startAnalysis(config);
         }
     }
 

--- a/lib/RexStanRunStore.php
+++ b/lib/RexStanRunStore.php
@@ -73,6 +73,21 @@ final class RexStanRunStore
         return rex_file::get(self::errorLogPath(), '');
     }
 
+    /**
+     * @return int|null unix timestamp the cached result was generated at, null if there is none
+     */
+    public static function getCachedResultTimestamp(): ?int
+    {
+        $path = self::resultPath();
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $mtime = filemtime($path);
+
+        return false !== $mtime ? $mtime : null;
+    }
+
     public static function clearCachedResult(): void
     {
         @unlink(self::resultPath());

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -14,10 +14,20 @@ if ($regenerateBaseline) {
     RexStanRunStore::clearCachedResult();
 }
 
+// Plain-link fallback for when JS didn't load (e.g. after forgetting
+// assets:sync, or a blocked script) - reloads the page, which then shows the
+// "running" state below just like the AJAX-triggered flow does. JS below
+// intercepts this same link to avoid the page reload when it did load.
+$forceRerun = rex_get('rerun', 'bool', false);
+if ($forceRerun) {
+    RexStan::startBackgroundWebAnalysis();
+}
+
 rex_view::addJsFile($this->getAssetsUrl('rexstan-analysis.js'));
 
 $isRunning = RexStanRunStore::isRunning();
 $cachedResult = $isRunning ? null : RexStanRunStore::readCachedResult();
+$resultTimestamp = $isRunning ? null : RexStanRunStore::getCachedResultTimestamp();
 
 if ($isRunning) {
     $initialHtml = '';
@@ -25,6 +35,23 @@ if ($isRunning) {
     $initialHtml = RexResultsRenderer::renderAnalysisBody($cachedResult, $regenerateBaseline);
 } else {
     $initialHtml = '';
+}
+
+$rerunUrl = rex_url::backendPage('rexstan/analysis', ['rerun' => 1]);
+
+$toolbarHtml = '';
+if (!$isRunning) {
+    $label = (null !== $cachedResult) ? '🔄 Neu analysieren' : '▶️ Analyse starten';
+    // rex_url::backendPage() already returns a pre-escaped URL (escape=true default) -
+    // wrapping it in rex_escape() again would double-escape the "&" into "&amp;amp;"
+    $toolbarHtml = '<p><a href="'. $rerunUrl .'" id="rexstan-analysis-trigger" class="btn btn-primary">'. $label .'</a></p>';
+}
+
+$metaHtml = '';
+if (null !== $resultTimestamp) {
+    $metaHtml = '<p class="text-muted" id="rexstan-analysis-meta">Ergebnis vom '. rex_escape(date('d.m.Y H:i', $resultTimestamp)) .' Uhr</p>';
+} elseif ($isRunning) {
+    $metaHtml = '<p class="text-muted" id="rexstan-analysis-meta"></p>';
 }
 
 $jsConfig = json_encode([
@@ -35,6 +62,7 @@ $jsConfig = json_encode([
 
 echo '<div id="rexstan-analysis-config" data-config="'. rex_escape($jsConfig) .'" hidden></div>';
 echo '<div id="rexstan-analysis-app">';
-echo '<div id="rexstan-analysis-toolbar"></div>';
+echo '<div id="rexstan-analysis-toolbar">'. $toolbarHtml .'</div>';
+echo '<div id="rexstan-analysis-meta-container">'. $metaHtml .'</div>';
 echo '<div id="rexstan-analysis-result">'. $initialHtml .'</div>';
 echo '</div>';


### PR DESCRIPTION
## Summary

Stacked on #1061 (the non-blocking analysis page) — please review/merge that one first.

The trigger was only ever a JS-created `<button>`, with nothing server-rendered at all if JS never ran. During development, a forgotten `assets:sync` after editing `assets/rexstan-analysis.js` meant the button silently never appeared - reloading the page didn't help either, since nothing about the trigger was server-side to begin with.

The trigger is now a normal server-rendered link (`?rerun=1`), so it always renders and works even without JS - clicking it reloads the page, which starts the background run and shows the running state. JS still intercepts the same click to avoid the reload when it did load, and no longer auto-starts a run on the very first page view (previously silent/surprising) in favor of this always-visible link.

Also shows the timestamp the currently displayed result was generated at (`RexStanRunStore::getCachedResultTimestamp()`), so it's clear when what's on screen isn't from the just-finished run; updates to "just now" client-side once a poll completes.

## Test plan
- [x] Verified the link renders correctly and isn't double-escaped (`rex_url::backendPage()` already returns a pre-escaped URL).
- [x] Verified the no-JS path: clicking reloads the page and starts a background run.
- [x] `php -l` + PHPStan on the changed files: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)