### PR TITLE
Fix the analysis re-run button silently doing nothing

### DIFF
--- a/assets/rexstan-analysis.js
+++ b/assets/rexstan-analysis.js
@@ -150,6 +150,14 @@
             return;
         }
 
+        // init() runs from multiple triggers below (rex:ready, DOMContentLoaded,
+        // the unconditional call at load time) to cover every timing case -
+        // guard against binding/polling more than once per page load.
+        if (app.dataset.rexstanAnalysisInit === '1') {
+            return;
+        }
+        app.dataset.rexstanAnalysisInit = '1';
+
         var config = loadConfig();
         if (typeof config.apiBase !== 'string' || config.apiBase === '') {
             return;
@@ -165,5 +173,20 @@
         }
     }
 
-    document.addEventListener('DOMContentLoaded', init);
+    // Same pattern as this project's other backend JS (e.g.
+    // ai-chat-warm-cache.js): a script tag added via rex_view::addJsFile() can
+    // finish loading/executing AFTER DOMContentLoaded already fired, in which
+    // case that listener alone would never call init() at all - no click
+    // handler would ever get bound, and the button would silently do nothing.
+    // rex:ready additionally covers REDAXO's own AJAX-driven content swaps,
+    // and the unconditional call handles the "DOM is already ready by the
+    // time this script runs" case immediately.
+    if (typeof jQuery !== 'undefined') {
+        jQuery(document).on('rex:ready', function () {
+            init();
+        });
+    } else {
+        document.addEventListener('DOMContentLoaded', init);
+    }
+    init();
 }());

--- a/boot.php
+++ b/boot.php
@@ -22,6 +22,9 @@ if (rex::isBackend() && is_object(rex::getUser())) {
     if (rex_be_controller::getCurrentPagePart(1) === 'rexstan') {
         rex_view::addJsFile($addon->getAssetsUrl('confetti.min.js'));
     }
+    if (rex_be_controller::getCurrentPagePart(2) === 'analysis') {
+        rex_view::addJsFile($addon->getAssetsUrl('rexstan-analysis.js'));
+    }
 }
 
 rex_extension::register('PACKAGE_CACHE_DELETED', static function (rex_extension_point $ep) {

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -23,7 +23,8 @@ if ($forceRerun) {
     RexStan::startBackgroundWebAnalysis();
 }
 
-rex_view::addJsFile($this->getAssetsUrl('rexstan-analysis.js'));
+// JS is registered in boot.php (gated to this subpage), not here - see the
+// comment there for why (matches this addon's own confetti.min.js pattern).
 
 $isRunning = RexStanRunStore::isRunning();
 $cachedResult = $isRunning ? null : RexStanRunStore::readCachedResult();


### PR DESCRIPTION
## Summary

Stacked on #1062 (toolbar hardening) — please review/merge that one first.

The button's click handler was only ever bound from a `DOMContentLoaded` listener. A script added via `rex_view::addJsFile()` can finish loading/executing *after* that event already fired (common on a backend page with many other scripts), in which case the listener never runs at all - no handler ever gets bound, and the link's `href="#"` just does nothing on click, which is exactly what was being observed.

Fixed the same way this project's own `ai-chat-warm-cache.js` already does it: try a jQuery `rex:ready` listener (also covers REDAXO's own AJAX-driven content swaps), fall back to `DOMContentLoaded`, and call `init()` unconditionally as well to cover the case where the DOM is already ready by the time this script runs. `init()` now guards against running its setup more than once per page load (a dataset flag on the app root), since it can legitimately fire from multiple triggers now.

Also moved the script registration from `pages/analysis.php` into `boot.php`, gated to this subpage specifically - matches this addon's own existing `confetti.min.js` pattern instead of introducing a second, different way of loading a JS file for the same page.

## Test plan
- [x] Verified the click handler binds and fires correctly regardless of load timing (tested the "script loads after DOMContentLoaded" race specifically).
- [x] `php -l` + PHPStan on the changed files: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)