### PR TITLE
Add a real animated spinner for the "running" placeholder

### DIFF
--- a/assets/rexstan-analysis.js
+++ b/assets/rexstan-analysis.js
@@ -34,8 +34,8 @@
     }
 
     function renderRunningPlaceholder() {
-        return '<div class="rex-view rex-view-info" style="text-align:center;">'
-            + '<p><span class="rexstan-analysis-spinner">&#9203;</span> Analyse läuft im Hintergrund … diese Seite aktualisiert sich automatisch, sobald sie fertig ist.</p>'
+        return '<div class="rex-view rex-view-info rexstan-analysis-running" style="text-align:center;">'
+            + '<p><span class="rexstan-analysis-spinner" aria-hidden="true"></span>Analyse läuft im Hintergrund … diese Seite aktualisiert sich automatisch, sobald sie fertig ist.</p>'
             + '</div>';
     }
 

--- a/assets/rexstan.css
+++ b/assets/rexstan.css
@@ -53,3 +53,25 @@ div.page-header h1 span.rexstan-logo img {
 .rexstan-graph {
     margin-bottom: -30px;
 }
+
+.rexstan-analysis-running {
+    padding: 30px 15px;
+}
+
+.rexstan-analysis-spinner {
+    display: inline-block;
+    width: 22px;
+    height: 22px;
+    vertical-align: middle;
+    margin-right: 10px;
+    border: 3px solid rgba(0, 0, 0, 0.15);
+    border-top-color: currentColor;
+    border-radius: 50%;
+    animation: rexstan-spin 0.7s linear infinite;
+}
+
+@keyframes rexstan-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -31,7 +31,12 @@ $cachedResult = $isRunning ? null : RexStanRunStore::readCachedResult();
 $resultTimestamp = $isRunning ? null : RexStanRunStore::getCachedResultTimestamp();
 
 if ($isRunning) {
-    $initialHtml = '';
+    // mirrors assets/rexstan-analysis.js's renderRunningPlaceholder() - shown
+    // immediately (animated via pure CSS) rather than waiting for JS, which
+    // may not have bound/run yet at this exact moment
+    $initialHtml = '<div class="rex-view rex-view-info rexstan-analysis-running" style="text-align:center;">'
+        .'<p><span class="rexstan-analysis-spinner" aria-hidden="true"></span>Analyse läuft im Hintergrund … diese Seite aktualisiert sich automatisch, sobald sie fertig ist.</p>'
+        .'</div>';
 } elseif (null !== $cachedResult) {
     $initialHtml = RexResultsRenderer::renderAnalysisBody($cachedResult, $regenerateBaseline);
 } else {


### PR DESCRIPTION
## Summary

Stacked on #1063 (click-handler fix) — please review/merge that one first.

The running-state placeholder referenced a `rexstan-analysis-spinner` CSS class that was never actually defined - just a static hourglass emoji with no animation at all, easy to miss.

Added a small rotating CSS spinner (`assets/rexstan.css`) and render the exact same placeholder markup server-side in `pages/analysis.php` as well as from JS, so it's visible and animated purely via CSS immediately on page load when a run is already in progress, without depending on JS having initialized yet.

## Test plan
- [x] Verified the spinner markup and CSS class render correctly server-side (forced a "running" lock state and checked the output).
- [x] `php -l` on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)