### PR TITLE
Make the analysis web UI non-blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+Alle wichtigen Änderungen an diesem Projekt werden in dieser Datei dokumentiert.
+
+Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.0.0/),
+und dieses Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
+
+## [Unreleased]
+
+### 🚀 New Features (Neue Funktionen)
+
+#### Added (Hinzugefügt)
+
+- **Nicht-blockierende Analyse-Seite**: `rexstan/analysis` blockiert den Browser-Request nicht mehr für die gesamte Dauer eines PHPStan-Laufs. Die Seite lädt sofort (zeigt das zuletzt gecachte Ergebnis inkl. eines "Neu analysieren"-Buttons, oder startet beim allerersten Aufruf automatisch einen Lauf), ein Analyse-Lauf wird als abgekoppelter Hintergrundprozess gestartet, und kleines JS pollt den Fortschritt, bis das Ergebnis fertig ist und tauscht es dann ohne Seiten-Reload aus.
+  - Neuer Ajax-Endpunkt `index.php?rex-api-call=rexstan_analysis&action=start|status` (`lib/Api/AnalysisApi.php`).
+  - Lauf-Status/-Ergebnis wird dateibasiert persistiert (`lib/RexStanRunStore.php`) statt an den auslösenden Request gebunden zu sein – ein verwaister/abgestürzter Hintergrundlauf blockiert nach 15 Minuten automatisch keine neuen Läufe mehr.
+  - `RexStan::startBackgroundWebAnalysis()` spawnt den PHPStan-Lauf detached (Unix: `shell_exec('(...) &')`, Windows: `start /B`); Ergebnis wird atomar (erst in eine Temp-Datei, dann per `mv`/`move`) an seinen finalen Pfad geschrieben, damit ein Poller nie eine unvollständige Ergebnisdatei zu sehen bekommt.
+  - `RexResultsRenderer::renderAnalysisBody()` extrahiert die bisher direkt in `pages/analysis.php` liegende Rendering-Logik in eine wiederverwendbare Methode, die sowohl beim normalen Seitenaufruf (gecachtes Ergebnis) als auch von der Ajax-Statusabfrage (frisches Ergebnis) genutzt wird.
+
+### 🧹 Code Quality
+
+- `RexStan::runFromWeb()`'s Interpretation der rohen PHPStan-Ausgabe (JSON vs. Klartext-Fehler) in `RexStan::interpretAnalysisOutput()` extrahiert, damit sowohl der synchrone als auch der neue Hintergrund-Pfad dieselbe Logik nutzen.
+- PSR-3-Log-Interpolation statt String-Konkatenation in `RexStan::interpretAnalysisOutput()`.
+
+### ⚠️ Bekannte Einschränkungen
+
+- Hintergrundausführung erfordert `shell_exec()`/`proc_open()` (auf Unix) bzw. `popen()` (auf Windows) – auf Hosts, auf denen das deaktiviert ist, ist dieselbe Einschränkung wie bisher bei der Web-UI insgesamt gegeben (siehe README: "Die Web UI funktioniert nicht auf allen Systemen"). Ein sauberer Fallback auf den bisherigen synchronen Weg fehlt in dieser Version noch.
+- Kein manueller Abbruch eines laufenden Hintergrund-Laufs (nur automatische Stale-Erkennung nach 15 Minuten).

--- a/assets/rexstan-analysis.js
+++ b/assets/rexstan-analysis.js
@@ -1,0 +1,155 @@
+(function () {
+    'use strict';
+
+    var POLL_INTERVAL_MS = 2000;
+    var pollTimer = null;
+
+    function el(id) {
+        return document.getElementById(id);
+    }
+
+    function loadConfig() {
+        var cfgEl = el('rexstan-analysis-config');
+        if (!cfgEl) {
+            return {};
+        }
+
+        try {
+            return JSON.parse(cfgEl.dataset.config || '{}');
+        } catch (e) {
+            return {};
+        }
+    }
+
+    function fetchJson(url) {
+        return fetch(url, {
+            headers: {
+                'Accept': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            credentials: 'same-origin'
+        }).then(function (response) {
+            return response.json();
+        });
+    }
+
+    function renderRunningPlaceholder() {
+        return '<div class="rex-view rex-view-info" style="text-align:center;">'
+            + '<p><span class="rexstan-analysis-spinner">&#9203;</span> Analyse läuft im Hintergrund … diese Seite aktualisiert sich automatisch, sobald sie fertig ist.</p>'
+            + '</div>';
+    }
+
+    function setToolbar(config, running) {
+        var toolbar = el('rexstan-analysis-toolbar');
+        if (!toolbar) {
+            return;
+        }
+
+        if (running) {
+            toolbar.innerHTML = '';
+            return;
+        }
+
+        var label = config.hasResult ? '🔄 Neu analysieren' : '▶️ Analyse starten';
+        toolbar.innerHTML = '<p><button type="button" id="rexstan-analysis-trigger" class="btn btn-primary">' + label + '</button></p>';
+
+        var btn = el('rexstan-analysis-trigger');
+        if (btn) {
+            btn.addEventListener('click', function () {
+                startAnalysis(config);
+            });
+        }
+    }
+
+    function stopPolling() {
+        if (pollTimer !== null) {
+            clearInterval(pollTimer);
+            pollTimer = null;
+        }
+    }
+
+    function poll(config) {
+        fetchJson(config.apiBase + '&action=status')
+            .then(function (data) {
+                if (!data || !data.success) {
+                    stopPolling();
+                    el('rexstan-analysis-result').innerHTML =
+                        '<div class="rex-view rex-view-error">Fehler beim Abrufen des Analyse-Status'
+                        + (data && data.error ? ': ' + data.error : '')
+                        + '</div>';
+                    setToolbar(config, false);
+                    return;
+                }
+
+                if (data.running) {
+                    // still running - keep the interval going, nothing to update yet
+                    return;
+                }
+
+                stopPolling();
+                config.hasResult = true;
+                el('rexstan-analysis-result').innerHTML = data.html || '';
+                setToolbar(config, false);
+            })
+            .catch(function () {
+                // a single failed poll (e.g. transient network hiccup) shouldn't
+                // give up on the whole run - just try again on the next tick
+            });
+    }
+
+    function startAnalysis(config) {
+        el('rexstan-analysis-result').innerHTML = renderRunningPlaceholder();
+        setToolbar(config, true);
+
+        fetchJson(config.apiBase + '&action=start')
+            .then(function (data) {
+                if (!data || !data.success) {
+                    el('rexstan-analysis-result').innerHTML =
+                        '<div class="rex-view rex-view-error">Fehler beim Starten der Analyse'
+                        + (data && data.error ? ': ' + data.error : '')
+                        + '</div>';
+                    setToolbar(config, false);
+                    return;
+                }
+
+                stopPolling();
+                pollTimer = setInterval(function () {
+                    poll(config);
+                }, POLL_INTERVAL_MS);
+            })
+            .catch(function () {
+                el('rexstan-analysis-result').innerHTML =
+                    '<div class="rex-view rex-view-error">Netzwerkfehler beim Starten der Analyse.</div>';
+                setToolbar(config, false);
+            });
+    }
+
+    function init() {
+        var app = el('rexstan-analysis-app');
+        if (!app) {
+            return;
+        }
+
+        var config = loadConfig();
+        if (typeof config.apiBase !== 'string' || config.apiBase === '') {
+            return;
+        }
+
+        setToolbar(config, !!config.running);
+
+        if (config.running) {
+            pollTimer = setInterval(function () {
+                poll(config);
+            }, POLL_INTERVAL_MS);
+            return;
+        }
+
+        if (!config.hasResult) {
+            // nothing cached yet on this system - kick off the very first run
+            // automatically instead of showing an empty page
+            startAnalysis(config);
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', init);
+}());

--- a/boot.php
+++ b/boot.php
@@ -1,8 +1,11 @@
 <?php
 
+use FriendsOfRedaxo\RexStan\Api\AnalysisApi;
 use FriendsOfRedaxo\RexStan\RexStan;
 
 $addon = rex_addon::get('rexstan');
+
+rex_api_function::register('rexstan_analysis', AnalysisApi::class);
 
 if (rex::isBackend() && is_object(rex::getUser())) {
     rex_extension::register('OUTPUT_FILTER', static function (rex_extension_point $ep) use ($addon) {

--- a/lib/Api/AnalysisApi.php
+++ b/lib/Api/AnalysisApi.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace FriendsOfRedaxo\RexStan\Api;
+
+use FriendsOfRedaxo\RexStan\RexResultsRenderer;
+use FriendsOfRedaxo\RexStan\RexStan;
+use FriendsOfRedaxo\RexStan\RexStanRunStore;
+use rex;
+use rex_api_exception;
+use rex_api_function;
+use rex_request;
+
+/**
+ * Ajax endpoint backing the non-blocking analysis page (pages/analysis.php +
+ * assets/rexstan-analysis.js): starting a PHPStan run and checking on its
+ * result must not themselves block on however long the run takes, otherwise
+ * we'd be back to the original blocking-page problem, just moved into an
+ * XHR request instead of the page load itself.
+ *
+ * Registered in boot.php as "rexstan_analysis". Called as
+ * "index.php?rex-api-call=rexstan_analysis&action=start|status" - no "page"
+ * parameter is required, the permission check happens explicitly below
+ * (mirrors other backend-only rex_api_function endpoints in this ecosystem).
+ */
+class AnalysisApi extends rex_api_function
+{
+    use JsonResponseTrait;
+
+    protected $published = false;
+
+    public function execute()
+    {
+        $user = rex::getUser();
+        if (!$user || !$user->isAdmin()) {
+            throw new rex_api_exception('Unauthorized');
+        }
+
+        // A background run doesn't need this request's session locked, and
+        // holding it would block every other backend tab/request until this
+        // one returns.
+        if (session_id()) {
+            session_write_close();
+        }
+
+        ob_start();
+
+        $action = rex_request('action', 'string', '');
+
+        if ('start' === $action) {
+            $this->handleStart();
+        }
+
+        if ('status' === $action) {
+            $this->handleStatus();
+        }
+
+        $this->sendJsonClean(['success' => false, 'error' => 'Unknown action']);
+    }
+
+    private function handleStart(): void
+    {
+        if (RexStanRunStore::isRunning()) {
+            $this->sendJsonClean(['success' => true, 'started' => false, 'reason' => 'already_running']);
+        }
+
+        $started = RexStan::startBackgroundWebAnalysis();
+        if (!$started) {
+            $this->sendJsonClean(['success' => true, 'started' => false, 'reason' => 'already_running']);
+        }
+
+        $this->sendJsonClean(['success' => true, 'started' => true]);
+    }
+
+    private function handleStatus(): void
+    {
+        if (RexStanRunStore::isRunning()) {
+            $this->sendJsonClean(['success' => true, 'running' => true]);
+        }
+
+        $result = RexStanRunStore::readCachedResult();
+        if (null === $result) {
+            // finished, but no result made it into place - most likely the
+            // background process died before it could rename its result file
+            // into place; surface whatever ended up in its error log instead
+            // of leaving the polling UI stuck forever.
+            $errorLog = RexStanRunStore::readErrorLog();
+            $result = '' !== $errorLog ? $errorLog : 'Unbekannter Fehler: der Hintergrundlauf wurde beendet, ohne ein Ergebnis zu hinterlassen.';
+        }
+
+        $this->sendJsonClean([
+            'success' => true,
+            'running' => false,
+            'html' => RexResultsRenderer::renderAnalysisBody($result),
+        ]);
+    }
+}

--- a/lib/Api/JsonResponseTrait.php
+++ b/lib/Api/JsonResponseTrait.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FriendsOfRedaxo\RexStan\Api;
+
+use rex_response;
+
+/**
+ * A single PHP warning/notice that REDAXO's error handler writes directly into
+ * the output in debug mode would otherwise land BEFORE the JSON in the
+ * response body and make it invalid for any JSON parser - visible client-side
+ * often only as a cryptic network/parse error instead of a clear message.
+ *
+ * Usage: call ob_start() at the beginning of execute() (catches stray output),
+ * then use sendJsonClean() instead of rex_response::sendJson() directly before
+ * every response.
+ */
+trait JsonResponseTrait
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function sendJsonClean(array $data): never
+    {
+        while (ob_get_level() > 0) {
+            @ob_end_clean();
+        }
+
+        rex_response::sendJson($data);
+        exit;
+    }
+}

--- a/lib/RexResultsRenderer.php
+++ b/lib/RexResultsRenderer.php
@@ -6,6 +6,8 @@ use rex_editor;
 use rex_fragment;
 use rex_path;
 use rex_response;
+use rex_url;
+use rex_view;
 
 use function array_key_exists;
 use function count;
@@ -13,6 +15,138 @@ use function dirname;
 
 final class RexResultsRenderer
 {
+    /**
+     * Renders the full analysis result body - the same markup pages/analysis.php
+     * used to produce synchronously, now as a reusable string so it can also be
+     * returned by Api\AnalysisApi once a background run (see
+     * RexStan::startBackgroundWebAnalysis()) has finished, for the polling JS to
+     * inject into the page without a full reload.
+     *
+     * @param array<string, mixed>|string $phpstanResult
+     */
+    public static function renderAnalysisBody($phpstanResult, bool $regenerateBaseline = false): string
+    {
+        ob_start();
+
+        $settingsUrl = rex_url::backendPage('rexstan/settings');
+
+        if (is_string($phpstanResult)) {
+            // we moved settings files into config/.
+            if (stripos($phpstanResult, "neon' is missing or is not readable.") !== false) {
+                echo rex_view::warning(
+                    "Das Einstellungsformat hat sich geändert. Bitte die <a href='".$settingsUrl."'>Einstellungen öffnen</a> und erneut abspeichern. <br/><br/>".nl2br(
+                        $phpstanResult
+                    )
+                );
+            } elseif (stripos($phpstanResult, 'polyfill-php8') !== false && stripos($phpstanResult, 'does not exist') !== false) {
+                echo rex_view::warning(
+                    'Der REDAXO Core wurde aktualisiert. Bitte das rexstan AddOn re-installieren. <br/><br/>'.nl2br($phpstanResult)
+                );
+            } else {
+                echo rex_view::error(
+                    '<h4>PHPSTAN: Fehler</h4>'
+                    .nl2br($phpstanResult)
+                );
+            }
+
+            echo rex_view::info('Die Web UI funktionert nicht auf allen Systemen, siehe README.');
+
+            return ob_get_clean() ?: '';
+        }
+
+        $hasPhpstanErrors =
+            array_key_exists('errors', $phpstanResult)
+            && is_array($phpstanResult['errors'])
+            && $phpstanResult['errors'] !== []
+        ;
+
+        if (
+            !is_array($phpstanResult['files'])
+            || $hasPhpstanErrors
+        ) {
+            // print general php errors, like out of memory...
+            if ($hasPhpstanErrors) {
+                $msg = '<h4>PHPSTAN: Laufzeit-Fehler</h4><ul>';
+                foreach ($phpstanResult['errors'] as $error) {
+                    $msg .= '<li>'.nl2br($error).'<br /></li>';
+                }
+                $msg .= '</li>';
+                echo rex_view::error($msg);
+            } else {
+                echo rex_view::warning('No phpstan result');
+            }
+
+            return ob_get_clean() ?: '';
+        }
+
+        $totalErrors = $phpstanResult['totals']['file_errors'];
+
+        $baselineButton = '';
+        $baselineInfo = '';
+        $baselineCount = 0;
+        if (RexStanUserConfig::isBaselineEnabled()) {
+            if (!$regenerateBaseline) {
+                $baselineButton .= ' <a href="'. rex_url::backendPage('rexstan/analysis', ['regenerate-baseline' => 1]) .'" class="btn btn-danger">Alle Probleme ignorieren</a>';
+            }
+
+            $baselineCount = RexStan::getBaselineErrorsCount();
+            if ($baselineCount > 0) {
+                $baselineInfo = '<br/><i>'. $baselineCount .' Probleme wurden mittels Baseline ignoriert</i>';
+            }
+        }
+
+        if ($totalErrors === 0) {
+            $level = RexStanUserConfig::getLevel();
+            $emoji = self::getResultEmoji($level);
+
+            echo '<span class="rexstan-achievement">'.$emoji .'</span>';
+            echo rex_view::success('Gratulation, es wurden keine Fehler in Level '. $level .' gefunden.');
+
+            if ($level === 10) {
+                echo self::getLevel10Jseffect();
+            } else {
+                echo '<p>';
+
+                echo 'In den <a href="'. rex_url::backendPage('rexstan/settings') .'">Einstellungen</a>, solltest du jetzt das nächste Level anvisieren.';
+                if (RexStanUserConfig::isBaselineEnabled() && $baselineCount > 0) {
+                    $baselineFile = RexStanSettings::getAnalysisBaselinePath();
+                    $url = rex_editor::factory()->getUrl($baselineFile, 0);
+
+                    $baselineHint = 'Baseline '. $baselineCount .' Probleme ignoriert werden';
+                    if ($url !== null) {
+                        $baselineHint = '<a href="'. $url .'">'. $baselineHint .'</a>';
+                    }
+
+                    echo '<br />Da mittels '. $baselineHint .', solltest Du alternativ versuchen diese zu reduzieren.';
+                }
+
+                echo '</p>';
+            }
+            echo RexStanSettings::outputSettings();
+
+            return ob_get_clean() ?: '';
+        }
+
+        if ($regenerateBaseline && $totalErrors > 0) {
+            echo rex_view::error('Nicht alle Fehler konnten ignoriert werden. <b>Empfehlung:</b> Die verbliebenen kritischen Fehler analysieren und beheben.');
+        }
+
+        echo rex_view::warning(
+            'Level-<strong>'.RexStanUserConfig::getLevel().'</strong>-Analyse: <strong>'. $totalErrors .'</strong> Probleme gefunden in <strong>'. count($phpstanResult['files']) .'</strong> Dateien.'. $baselineButton. $baselineInfo
+        );
+
+        foreach ($phpstanResult['files'] as $file => $fileResult) {
+            $linkFile = preg_replace('/\s\(in context.*?$/', '', $file);
+            if ($linkFile === null) {
+                throw new \PHPStan\ShouldNotHappenException();
+            }
+
+            echo self::renderFileBlock($linkFile, $fileResult['messages']);
+        }
+
+        return ob_get_clean() ?: '';
+    }
+
     public static function getResultEmoji(int $level): string
     {
         $emoji = '';

--- a/lib/RexStan.php
+++ b/lib/RexStan.php
@@ -82,7 +82,7 @@ final class RexStan
         $addon = rex_addon::get('rexstan');
         $dataDir = $addon->getDataPath();
 
-        RexCmd::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline '. $analysisBaselinePath .' --allow-empty-baseline', $stderrOutput, $exitCode);
+        RexCmd::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline '. $analysisBaselinePath .' --allow-empty-baseline --no-progress', $stderrOutput, $exitCode);
         if ($exitCode !== 0) {
             throw new Exception('Unable to generate analysis baseline:'. $stderrOutput);
         }
@@ -111,7 +111,7 @@ final class RexStan
         $baselineGlob = $dataDir.$configSignature.DIRECTORY_SEPARATOR.'*-summary.json';
         $htmlGraphPath = $dataDir.'baseline-graph.html';
 
-        RexCmd::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline --allow-empty-baseline', $stderrOutput, $exitCode);
+        RexCmd::execCmd('cd '.$dataDir.' && '. $phpstanBinary .' analyse -c '. $configPath .' --generate-baseline --allow-empty-baseline --no-progress', $stderrOutput, $exitCode);
         if ($exitCode !== 0) {
             throw new Exception('Unable to generate baseline:'. $stderrOutput);
         }

--- a/lib/RexStan.php
+++ b/lib/RexStan.php
@@ -49,12 +49,71 @@ final class RexStan
         $cmd = $phpstanBinary .' analyse -c '. $configPath .' --error-format=json --no-progress';
         $output = RexCmd::execCmd($cmd, $stderrOutput, $exitCode);
 
+        return self::interpretAnalysisOutput($output, $stderrOutput);
+    }
+
+    /**
+     * Starts a "runFromWeb()"-equivalent analysis as a detached background
+     * process instead of blocking the current request. Progress/result is
+     * tracked exclusively via RexStanRunStore, so the browser can poll for it
+     * (see Api\AnalysisApi) instead of waiting on this call itself.
+     *
+     * @return bool false if a background run is already in progress
+     */
+    public static function startBackgroundWebAnalysis(): bool
+    {
+        if (RexStanRunStore::isRunning()) {
+            return false;
+        }
+
+        $phpstanBinary = self::phpstanBinPath();
+        $configPath = self::phpstanConfigPath(__DIR__.'/../phpstan.neon');
+        $cmd = $phpstanBinary .' analyse -c '. $configPath .' --error-format=json --no-progress';
+
+        RexStanRunStore::markStarted();
+
+        $resultTmp = RexStanRunStore::resultTmpPath();
+        $result = RexStanRunStore::resultPath();
+        $errorLog = RexStanRunStore::errorLogPath();
+        $lock = RexStanRunStore::lockPath();
+
+        if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
+            // Best effort on Windows: no directly equivalent primitive to Unix's
+            // detached "&" backgrounding exists for cmd.exe: "start /B" is the
+            // closest match and is spawned already-detached from this request.
+            $wrapped = 'cmd /C "'. $cmd .' > '. escapeshellarg($resultTmp) .' 2> '. escapeshellarg($errorLog)
+                .' & move /Y '. escapeshellarg($resultTmp) .' '. escapeshellarg($result)
+                .' & del '. escapeshellarg($lock) .'"';
+
+            $handle = popen('start /B '. $wrapped, 'r');
+            if (false !== $handle) {
+                pclose($handle);
+            }
+        } else {
+            // Write to a temp file first and rename it into place afterwards, so a
+            // poller can never observe a partially-written result file; remove the
+            // lock only once the result is safely in place.
+            $wrapped = '(' . $cmd . ' > '. escapeshellarg($resultTmp) .' 2> '. escapeshellarg($errorLog)
+                .'; mv '. escapeshellarg($resultTmp) .' '. escapeshellarg($result)
+                .'; rm -f '. escapeshellarg($lock) .') > /dev/null 2>&1 &';
+
+            shell_exec($wrapped);
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>|string
+     */
+    public static function interpretAnalysisOutput(string $output, string $stderrOutput)
+    {
         // return the analysis result as an array
         if ($output !== '' && $output[0] === '{') {
             $decoded = json_decode($output, true);
 
             if (json_last_error() != 0) {
-                rex_logger::factory()->warning("rexstan - invalid json:\n\n". $output);
+                rex_logger::factory()->warning('rexstan - invalid json:{output}', ['output' => "\n\n". $output]);
 
                 throw new Exception('Unable to decode json: '. json_last_error_msg() ."\n\nSee syslog for details");
             }

--- a/lib/RexStanRunStore.php
+++ b/lib/RexStanRunStore.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace FriendsOfRedaxo\RexStan;
+
+use rex_addon;
+use rex_file;
+
+/**
+ * Persists the state of a background "analyze" run (started from the web UI,
+ * see pages/analysis.php + Api\AnalysisApi) to plain files, so a detached
+ * background process and the browser polling for its result always agree on
+ * the same ground truth - without this, showing analysis results would mean
+ * blocking the whole page request on however long the actual PHPStan run
+ * takes, which can be minutes on a larger codebase.
+ */
+final class RexStanRunStore
+{
+    private const LOCK_FILE = 'web-analysis-running.lock';
+    private const RESULT_FILE = 'web-analysis-result.json';
+    private const RESULT_TMP_FILE = 'web-analysis-result.json.tmp';
+    private const ERROR_LOG_FILE = 'web-analysis-error.log';
+
+    // A lock older than this is treated as an orphaned/crashed run rather than
+    // an active one, so a new run can always be started instead of getting
+    // stuck forever behind a background process that died without cleaning
+    // up after itself (e.g. killed by a deploy, OOM, hosting time limit).
+    private const STALE_AFTER_SECONDS = 900;
+
+    public static function isRunning(): bool
+    {
+        $path = self::lockPath();
+        if (!is_file($path)) {
+            return false;
+        }
+
+        $startedAt = (int) rex_file::get($path, '0');
+        if ($startedAt > 0 && (time() - $startedAt) > self::STALE_AFTER_SECONDS) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static function markStarted(): void
+    {
+        rex_file::put(self::lockPath(), (string) time());
+    }
+
+    /**
+     * Reads the last completed background-run result.
+     *
+     * @return array<string, mixed>|string|null null if no cached result exists yet;
+     *                                           a string if PHPStan's output could not
+     *                                           be parsed as JSON (mirrors RexStan::runFromWeb())
+     */
+    public static function readCachedResult()
+    {
+        $path = self::resultPath();
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $content = rex_file::get($path, '');
+        if ('' === $content) {
+            return null;
+        }
+
+        return RexStan::interpretAnalysisOutput($content, '');
+    }
+
+    public static function readErrorLog(): string
+    {
+        return rex_file::get(self::errorLogPath(), '');
+    }
+
+    public static function clearCachedResult(): void
+    {
+        @unlink(self::resultPath());
+        @unlink(self::errorLogPath());
+    }
+
+    public static function lockPath(): string
+    {
+        return self::dataPath(self::LOCK_FILE);
+    }
+
+    public static function resultPath(): string
+    {
+        return self::dataPath(self::RESULT_FILE);
+    }
+
+    public static function resultTmpPath(): string
+    {
+        return self::dataPath(self::RESULT_TMP_FILE);
+    }
+
+    public static function errorLogPath(): string
+    {
+        return self::dataPath(self::ERROR_LOG_FILE);
+    }
+
+    private static function dataPath(string $file): string
+    {
+        return rex_addon::get('rexstan')->getDataPath($file);
+    }
+}

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -4,126 +4,37 @@
 
 use FriendsOfRedaxo\RexStan\RexResultsRenderer;
 use FriendsOfRedaxo\RexStan\RexStan;
-use FriendsOfRedaxo\RexStan\RexStanSettings;
-use FriendsOfRedaxo\RexStan\RexStanUserConfig;
+use FriendsOfRedaxo\RexStan\RexStanRunStore;
 
 $regenerateBaseline = rex_get('regenerate-baseline', 'bool', false);
 if ($regenerateBaseline) {
     RexStan::generateAnalysisBaseline();
+    // the cached result predates the baseline change and would otherwise keep
+    // showing now-ignored errors until the next manually triggered run
+    RexStanRunStore::clearCachedResult();
 }
 
-$phpstanResult = RexStan::runFromWeb();
-$settingsUrl = rex_url::backendPage('rexstan/settings');
+rex_view::addJsFile($this->getAssetsUrl('rexstan-analysis.js'));
 
-if (is_string($phpstanResult)) {
-    // we moved settings files into config/.
-    if (stripos($phpstanResult, "neon' is missing or is not readable.") !== false) {
-        echo rex_view::warning(
-            "Das Einstellungsformat hat sich geändert. Bitte die <a href='".$settingsUrl."'>Einstellungen öffnen</a> und erneut abspeichern. <br/><br/>".nl2br(
-                $phpstanResult
-            )
-        );
-    } elseif (stripos($phpstanResult, 'polyfill-php8') !== false && stripos($phpstanResult, 'does not exist') !== false) {
-        echo rex_view::warning(
-            'Der REDAXO Core wurde aktualisiert. Bitte das rexstan AddOn re-installieren. <br/><br/>'.nl2br($phpstanResult)
-        );
-    } else {
-        echo rex_view::error(
-            '<h4>PHPSTAN: Fehler</h4>'
-            .nl2br($phpstanResult)
-        );
-    }
+$isRunning = RexStanRunStore::isRunning();
+$cachedResult = $isRunning ? null : RexStanRunStore::readCachedResult();
 
-    echo rex_view::info('Die Web UI funktionert nicht auf allen Systemen, siehe README.');
-
-    return;
-}
-
-$hasPhpstanErrors =
-    is_array($phpstanResult)
-    && array_key_exists('errors', $phpstanResult)
-    && is_array($phpstanResult['errors'])
-    && $phpstanResult['errors'] !== []
-;
-
-if (
-    !is_array($phpstanResult)
-    || !is_array($phpstanResult['files'])
-    || $hasPhpstanErrors
-) {
-    // print general php errors, like out of memory...
-    if ($hasPhpstanErrors) {
-        $msg = '<h4>PHPSTAN: Laufzeit-Fehler</h4><ul>';
-        foreach ($phpstanResult['errors'] as $error) {
-            $msg .= '<li>'.nl2br($error).'<br /></li>';
-        }
-        $msg .= '</li>';
-        echo rex_view::error($msg);
-    } else {
-        echo rex_view::warning('No phpstan result');
-    }
+if ($isRunning) {
+    $initialHtml = '';
+} elseif (null !== $cachedResult) {
+    $initialHtml = RexResultsRenderer::renderAnalysisBody($cachedResult, $regenerateBaseline);
 } else {
-    $totalErrors = $phpstanResult['totals']['file_errors'];
-
-    $baselineButton = '';
-    $baselineInfo = '';
-    $baselineCount = 0;
-    if (RexStanUserConfig::isBaselineEnabled()) {
-        if (!$regenerateBaseline) {
-            $baselineButton .= ' <a href="'. rex_url::backendPage('rexstan/analysis', ['regenerate-baseline' => 1]) .'" class="btn btn-danger">Alle Probleme ignorieren</a>';
-        }
-
-        $baselineCount = RexStan::getBaselineErrorsCount();
-        if ($baselineCount > 0) {
-            $baselineInfo = '<br/><i>'. $baselineCount .' Probleme wurden mittels Baseline ignoriert</i>';
-        }
-    }
-
-    if ($totalErrors === 0) {
-        $level = RexStanUserConfig::getLevel();
-        $emoji = RexResultsRenderer::getResultEmoji($level);
-
-        echo '<span class="rexstan-achievement">'.$emoji .'</span>';
-        echo rex_view::success('Gratulation, es wurden keine Fehler in Level '. $level .' gefunden.');
-
-        if ($level === 10) {
-            echo RexResultsRenderer::getLevel10Jseffect();
-        } else {
-            echo '<p>';
-
-            echo 'In den <a href="'. rex_url::backendPage('rexstan/settings') .'">Einstellungen</a>, solltest du jetzt das nächste Level anvisieren.';
-            if (RexStanUserConfig::isBaselineEnabled() && $baselineCount > 0) {
-                $baselineFile = RexStanSettings::getAnalysisBaselinePath();
-                $url = \rex_editor::factory()->getUrl($baselineFile, 0);
-
-                $baselineHint = 'Baseline '. $baselineCount .' Probleme ignoriert werden';
-                if ($url !== null) {
-                    $baselineHint = '<a href="'. $url .'">'. $baselineHint .'</a>';
-                }
-
-                echo '<br />Da mittels '. $baselineHint .', solltest Du alternativ versuchen diese zu reduzieren.';
-            }
-
-            echo '</p>';
-        }
-        echo RexStanSettings::outputSettings();
-        return;
-    }
-
-    if ($regenerateBaseline && $totalErrors > 0) {
-        echo rex_view::error('Nicht alle Fehler konnten ignoriert werden. <b>Empfehlung:</b> Die verbliebenen kritischen Fehler analysieren und beheben.');
-    }
-
-    echo rex_view::warning(
-        'Level-<strong>'.RexStanUserConfig::getLevel().'</strong>-Analyse: <strong>'. $totalErrors .'</strong> Probleme gefunden in <strong>'. count($phpstanResult['files']) .'</strong> Dateien.'. $baselineButton. $baselineInfo
-    );
-
-    foreach ($phpstanResult['files'] as $file => $fileResult) {
-        $linkFile = preg_replace('/\s\(in context.*?$/', '', $file);
-        if ($linkFile === null) {
-            throw new \PHPStan\ShouldNotHappenException();
-        }
-
-        echo RexResultsRenderer::renderFileBlock($linkFile, $fileResult['messages']);
-    }
+    $initialHtml = '';
 }
+
+$jsConfig = json_encode([
+    'apiBase' => 'index.php?rex-api-call=rexstan_analysis',
+    'running' => $isRunning,
+    'hasResult' => null !== $cachedResult,
+]);
+
+echo '<div id="rexstan-analysis-config" data-config="'. rex_escape($jsConfig) .'" hidden></div>';
+echo '<div id="rexstan-analysis-app">';
+echo '<div id="rexstan-analysis-toolbar"></div>';
+echo '<div id="rexstan-analysis-result">'. $initialHtml .'</div>';
+echo '</div>';


### PR DESCRIPTION
## Summary

Recreated from #1061 (closed) as part of flattening what had grown into a 5-deep PR stack (#1061→#1065) into a small set of independent PRs. This PR's content is unchanged from #1061 — only the PR itself is fresh, so it isn't tied into GitHub's native stacked-PR tracking that blocked retargeting individual PRs later on.

`pages/analysis.php` previously ran `RexStan::runFromWeb()` synchronously, blocking the whole page request for however long the PHPStan run took (seconds to minutes on a larger codebase), with the attendant risk of hitting `max_execution_time` or a reverse-proxy timeout.

The page now loads instantly:
- if a background run is already in progress, it shows a spinner and starts polling immediately;
- otherwise it shows the last cached result (if any) plus a re-run button;
- on the very first run on a system (no cache yet), it kicks off a background run automatically.

New pieces:
- `RexStanRunStore`: file-based state (lock/result/error-log) shared between the detached background process and the polling requests. A lock older than 15 minutes is treated as an orphaned/crashed run rather than an active one, so a dead background process can never permanently block future runs.
- `RexStan::startBackgroundWebAnalysis()`: spawns the same PHPStan invocation `runFromWeb()` already used, detached from the request (Unix: `shell_exec('(...) &')`, Windows: `start /B`). The result is written to a temp file first and renamed into place afterwards, so a poller can never observe a partially-written result.
- `Api\AnalysisApi`: the ajax endpoint backing start/status polling, registered as `rexstan_analysis`. Mirrors the `ob_start()`+clean-JSON-response guard and the `session_write_close()`-before-long-running-work pattern used elsewhere in this ecosystem for the same reasons.
- `RexResultsRenderer::renderAnalysisBody()`: the rendering logic that used to live directly in `pages/analysis.php`, extracted so both the page (cached result) and the status endpoint (fresh result) render identical markup.

Also extracted `RexStan::interpretAnalysisOutput()` (the JSON-vs-plain-text interpretation of PHPStan's raw output) out of `runFromWeb()` so both the synchronous and the new background path share it, and fixed a pre-existing PSR-3 log-interpolation finding on the line it moved.

Two independent, non-stacked follow-up PRs build on top of this one (base = this branch, not on each other):
- UI polish for the re-run trigger (no-JS fallback, timestamp, click-handler fix, spinner)
- A "consider a lower level" hint for very noisy runs

### Known limitations
- No fallback to the old synchronous behavior on hosts where `shell_exec()`/`proc_open()` is unavailable.
- No manual cancel of a running background analysis (only automatic stale-detection after 15 minutes).

## Test plan
- [x] Manual end-to-end test: start returns instantly, `isRunning()` correctly reflects state, double-start is rejected, background completion is detected, atomic rename verified.
- [x] Verified the background run produces byte-identical results to a direct, uncached `phpstan analyse` invocation (ruling out any shortcut/staleness).
- [x] `php -l` on all changed/added files; PHPStan on all new/changed files: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)