### PR TITLE
Harden, fix and animate the analysis re-run trigger

### DIFF
--- a/assets/rexstan-analysis.js
+++ b/assets/rexstan-analysis.js
@@ -39,6 +39,10 @@
             + '</div>';
     }
 
+    // The trigger link is always server-rendered already (works without JS,
+    // it just reloads the page instead of running this AJAX flow) - this only
+    // (re-)binds the click handler and toggles its visibility/label, it never
+    // builds the link's markup itself.
     function setToolbar(config, running) {
         var toolbar = el('rexstan-analysis-toolbar');
         if (!toolbar) {
@@ -50,14 +54,28 @@
             return;
         }
 
-        var label = config.hasResult ? '🔄 Neu analysieren' : '▶️ Analyse starten';
-        toolbar.innerHTML = '<p><button type="button" id="rexstan-analysis-trigger" class="btn btn-primary">' + label + '</button></p>';
-
         var btn = el('rexstan-analysis-trigger');
-        if (btn) {
-            btn.addEventListener('click', function () {
+        if (!btn) {
+            var label = config.hasResult ? '🔄 Neu analysieren' : '▶️ Analyse starten';
+            toolbar.innerHTML = '<p><a href="#" id="rexstan-analysis-trigger" class="btn btn-primary">' + label + '</a></p>';
+            btn = el('rexstan-analysis-trigger');
+        } else {
+            btn.textContent = config.hasResult ? '🔄 Neu analysieren' : '▶️ Analyse starten';
+        }
+
+        if (btn && btn.dataset.bound !== '1') {
+            btn.dataset.bound = '1';
+            btn.addEventListener('click', function (event) {
+                event.preventDefault();
                 startAnalysis(config);
             });
+        }
+    }
+
+    function setMeta(text) {
+        var meta = el('rexstan-analysis-meta');
+        if (meta) {
+            meta.textContent = text;
         }
     }
 
@@ -89,6 +107,7 @@
                 stopPolling();
                 config.hasResult = true;
                 el('rexstan-analysis-result').innerHTML = data.html || '';
+                setMeta('Ergebnis von gerade eben');
                 setToolbar(config, false);
             })
             .catch(function () {
@@ -99,6 +118,7 @@
 
     function startAnalysis(config) {
         el('rexstan-analysis-result').innerHTML = renderRunningPlaceholder();
+        setMeta('');
         setToolbar(config, true);
 
         fetchJson(config.apiBase + '&action=start')
@@ -138,16 +158,10 @@
         setToolbar(config, !!config.running);
 
         if (config.running) {
+            el('rexstan-analysis-result').innerHTML = renderRunningPlaceholder();
             pollTimer = setInterval(function () {
                 poll(config);
             }, POLL_INTERVAL_MS);
-            return;
-        }
-
-        if (!config.hasResult) {
-            // nothing cached yet on this system - kick off the very first run
-            // automatically instead of showing an empty page
-            startAnalysis(config);
         }
     }
 

--- a/assets/rexstan-analysis.js
+++ b/assets/rexstan-analysis.js
@@ -34,8 +34,8 @@
     }
 
     function renderRunningPlaceholder() {
-        return '<div class="rex-view rex-view-info" style="text-align:center;">'
-            + '<p><span class="rexstan-analysis-spinner">&#9203;</span> Analyse läuft im Hintergrund … diese Seite aktualisiert sich automatisch, sobald sie fertig ist.</p>'
+        return '<div class="rex-view rex-view-info rexstan-analysis-running" style="text-align:center;">'
+            + '<p><span class="rexstan-analysis-spinner" aria-hidden="true"></span>Analyse läuft im Hintergrund … diese Seite aktualisiert sich automatisch, sobald sie fertig ist.</p>'
             + '</div>';
     }
 

--- a/assets/rexstan-analysis.js
+++ b/assets/rexstan-analysis.js
@@ -150,6 +150,14 @@
             return;
         }
 
+        // init() runs from multiple triggers below (rex:ready, DOMContentLoaded,
+        // the unconditional call at load time) to cover every timing case -
+        // guard against binding/polling more than once per page load.
+        if (app.dataset.rexstanAnalysisInit === '1') {
+            return;
+        }
+        app.dataset.rexstanAnalysisInit = '1';
+
         var config = loadConfig();
         if (typeof config.apiBase !== 'string' || config.apiBase === '') {
             return;
@@ -165,5 +173,20 @@
         }
     }
 
-    document.addEventListener('DOMContentLoaded', init);
+    // Same pattern as this project's other backend JS (e.g.
+    // ai-chat-warm-cache.js): a script tag added via rex_view::addJsFile() can
+    // finish loading/executing AFTER DOMContentLoaded already fired, in which
+    // case that listener alone would never call init() at all - no click
+    // handler would ever get bound, and the button would silently do nothing.
+    // rex:ready additionally covers REDAXO's own AJAX-driven content swaps,
+    // and the unconditional call handles the "DOM is already ready by the
+    // time this script runs" case immediately.
+    if (typeof jQuery !== 'undefined') {
+        jQuery(document).on('rex:ready', function () {
+            init();
+        });
+    } else {
+        document.addEventListener('DOMContentLoaded', init);
+    }
+    init();
 }());

--- a/assets/rexstan.css
+++ b/assets/rexstan.css
@@ -53,3 +53,25 @@ div.page-header h1 span.rexstan-logo img {
 .rexstan-graph {
     margin-bottom: -30px;
 }
+
+.rexstan-analysis-running {
+    padding: 30px 15px;
+}
+
+.rexstan-analysis-spinner {
+    display: inline-block;
+    width: 22px;
+    height: 22px;
+    vertical-align: middle;
+    margin-right: 10px;
+    border: 3px solid rgba(0, 0, 0, 0.15);
+    border-top-color: currentColor;
+    border-radius: 50%;
+    animation: rexstan-spin 0.7s linear infinite;
+}
+
+@keyframes rexstan-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/boot.php
+++ b/boot.php
@@ -22,6 +22,9 @@ if (rex::isBackend() && is_object(rex::getUser())) {
     if (rex_be_controller::getCurrentPagePart(1) === 'rexstan') {
         rex_view::addJsFile($addon->getAssetsUrl('confetti.min.js'));
     }
+    if (rex_be_controller::getCurrentPagePart(2) === 'analysis') {
+        rex_view::addJsFile($addon->getAssetsUrl('rexstan-analysis.js'));
+    }
 }
 
 rex_extension::register('PACKAGE_CACHE_DELETED', static function (rex_extension_point $ep) {

--- a/lib/RexStanRunStore.php
+++ b/lib/RexStanRunStore.php
@@ -73,6 +73,21 @@ final class RexStanRunStore
         return rex_file::get(self::errorLogPath(), '');
     }
 
+    /**
+     * @return int|null unix timestamp the cached result was generated at, null if there is none
+     */
+    public static function getCachedResultTimestamp(): ?int
+    {
+        $path = self::resultPath();
+        if (!is_file($path)) {
+            return null;
+        }
+
+        $mtime = filemtime($path);
+
+        return false !== $mtime ? $mtime : null;
+    }
+
     public static function clearCachedResult(): void
     {
         @unlink(self::resultPath());

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -31,7 +31,12 @@ $cachedResult = $isRunning ? null : RexStanRunStore::readCachedResult();
 $resultTimestamp = $isRunning ? null : RexStanRunStore::getCachedResultTimestamp();
 
 if ($isRunning) {
-    $initialHtml = '';
+    // mirrors assets/rexstan-analysis.js's renderRunningPlaceholder() - shown
+    // immediately (animated via pure CSS) rather than waiting for JS, which
+    // may not have bound/run yet at this exact moment
+    $initialHtml = '<div class="rex-view rex-view-info rexstan-analysis-running" style="text-align:center;">'
+        .'<p><span class="rexstan-analysis-spinner" aria-hidden="true"></span>Analyse läuft im Hintergrund … diese Seite aktualisiert sich automatisch, sobald sie fertig ist.</p>'
+        .'</div>';
 } elseif (null !== $cachedResult) {
     $initialHtml = RexResultsRenderer::renderAnalysisBody($cachedResult, $regenerateBaseline);
 } else {

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -23,7 +23,8 @@ if ($forceRerun) {
     RexStan::startBackgroundWebAnalysis();
 }
 
-rex_view::addJsFile($this->getAssetsUrl('rexstan-analysis.js'));
+// JS is registered in boot.php (gated to this subpage), not here - see the
+// comment there for why (matches this addon's own confetti.min.js pattern).
 
 $isRunning = RexStanRunStore::isRunning();
 $cachedResult = $isRunning ? null : RexStanRunStore::readCachedResult();

--- a/pages/analysis.php
+++ b/pages/analysis.php
@@ -14,10 +14,20 @@ if ($regenerateBaseline) {
     RexStanRunStore::clearCachedResult();
 }
 
+// Plain-link fallback for when JS didn't load (e.g. after forgetting
+// assets:sync, or a blocked script) - reloads the page, which then shows the
+// "running" state below just like the AJAX-triggered flow does. JS below
+// intercepts this same link to avoid the page reload when it did load.
+$forceRerun = rex_get('rerun', 'bool', false);
+if ($forceRerun) {
+    RexStan::startBackgroundWebAnalysis();
+}
+
 rex_view::addJsFile($this->getAssetsUrl('rexstan-analysis.js'));
 
 $isRunning = RexStanRunStore::isRunning();
 $cachedResult = $isRunning ? null : RexStanRunStore::readCachedResult();
+$resultTimestamp = $isRunning ? null : RexStanRunStore::getCachedResultTimestamp();
 
 if ($isRunning) {
     $initialHtml = '';
@@ -25,6 +35,23 @@ if ($isRunning) {
     $initialHtml = RexResultsRenderer::renderAnalysisBody($cachedResult, $regenerateBaseline);
 } else {
     $initialHtml = '';
+}
+
+$rerunUrl = rex_url::backendPage('rexstan/analysis', ['rerun' => 1]);
+
+$toolbarHtml = '';
+if (!$isRunning) {
+    $label = (null !== $cachedResult) ? '🔄 Neu analysieren' : '▶️ Analyse starten';
+    // rex_url::backendPage() already returns a pre-escaped URL (escape=true default) -
+    // wrapping it in rex_escape() again would double-escape the "&" into "&amp;amp;"
+    $toolbarHtml = '<p><a href="'. $rerunUrl .'" id="rexstan-analysis-trigger" class="btn btn-primary">'. $label .'</a></p>';
+}
+
+$metaHtml = '';
+if (null !== $resultTimestamp) {
+    $metaHtml = '<p class="text-muted" id="rexstan-analysis-meta">Ergebnis vom '. rex_escape(date('d.m.Y H:i', $resultTimestamp)) .' Uhr</p>';
+} elseif ($isRunning) {
+    $metaHtml = '<p class="text-muted" id="rexstan-analysis-meta"></p>';
 }
 
 $jsConfig = json_encode([
@@ -35,6 +62,7 @@ $jsConfig = json_encode([
 
 echo '<div id="rexstan-analysis-config" data-config="'. rex_escape($jsConfig) .'" hidden></div>';
 echo '<div id="rexstan-analysis-app">';
-echo '<div id="rexstan-analysis-toolbar"></div>';
+echo '<div id="rexstan-analysis-toolbar">'. $toolbarHtml .'</div>';
+echo '<div id="rexstan-analysis-meta-container">'. $metaHtml .'</div>';
 echo '<div id="rexstan-analysis-result">'. $initialHtml .'</div>';
 echo '</div>';


### PR DESCRIPTION
## Summary

Independent sibling of #1068 (the "lower level" hint PR) — both are based on #1067 but not on each other. Combines what used to be three separate stacked PRs (#1062, #1063, #1064) into one, since all three touch the same small set of files around the same re-run trigger/toolbar and only really make sense read together.

- **No-JS fallback + timestamp**: the re-run trigger is now a real, server-rendered `<a href="...&rerun=1">` link that works even without JS (full page reload instead of the AJAX flow), and shows "Ergebnis vom …" once a cached result exists. JS intercepts the same link to avoid the reload when it did load.
- **Fix the re-run button silently doing nothing**: the script tag added via `rex_view::addJsFile()` from the page controller could finish loading *after* `DOMContentLoaded` had already fired, in which case that listener alone never called `init()` — no click handler was ever bound. Now also binds via `rex:ready` and calls `init()` unconditionally at load time (with a guard against double-binding), and the JS file itself is registered from `boot.php` (gated to this subpage) rather than the page.
- **Animated spinner**: the "running in background" placeholder gets a real CSS spinner instead of a static hourglass emoji, both for the JS-driven placeholder and the server-rendered initial one.

## Test plan
- [x] Verified the plain link works with JS disabled (full reload, correct running/result state).
- [x] Verified the click handler binds and the AJAX flow works when the script loads after `DOMContentLoaded`.
- [x] Verified the spinner animates in both the server-rendered initial state and the JS-swapped state.
- [x] `php -l` + PHPStan on all changed files: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)